### PR TITLE
Add debug logging for troubleshooting orbit runs

### DIFF
--- a/cmd/orbit/run.go
+++ b/cmd/orbit/run.go
@@ -22,6 +22,7 @@ func runCommand(args []string) error {
 	logDir := fs.String("log-dir", "", "Base directory for session logs (default: .orbit next to tasks file)")
 	skipPermissions := fs.Bool("skip-permissions", true, "Run Claude with --dangerously-skip-permissions")
 	verbose := fs.Bool("verbose", false, "Enable verbose output")
+	debug := fs.Bool("debug", false, "Enable debug logging (detailed CLI execution info)")
 	dryRun := fs.Bool("dry-run", false, "Show what would be executed without running")
 	showVersion := fs.Bool("version", false, "Show version and exit")
 	commandFlag := fs.String("command", "", "Custom prompt for Claude phases")
@@ -105,6 +106,12 @@ func runCommand(args []string) error {
 		continueSessionValue = false
 	}
 
+	// Resolve debug: CLI flag can enable (overrides config)
+	debugValue := cfg.Debug
+	if *debug {
+		debugValue = true
+	}
+
 	// Create and run orchestrator
 	orbitCfg := orbit.Config{
 		TasksFile:       *tasksFile,
@@ -112,6 +119,7 @@ func runCommand(args []string) error {
 		BranchName:      branchName,
 		SkipPermissions: *skipPermissions,
 		Verbose:         *verbose,
+		Debug:           debugValue,
 		DryRun:          *dryRun,
 		WorkingDir:      workingDir,
 		Command:         command,

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -6,19 +6,22 @@ import (
 	"encoding/json"
 	"os/exec"
 	"time"
+
+	"github.com/arjenschwarz/orbit/internal/debug"
 )
 
 // Result represents the JSON output from claude -p --output-format json.
 type Result struct {
-	Type         string  `json:"type"`
-	Subtype      string  `json:"subtype"`
-	TotalCostUSD float64 `json:"total_cost_usd"`
-	IsError      bool    `json:"is_error"`
-	DurationMS   int64   `json:"duration_ms"`
-	DurationAPI  int64   `json:"duration_api_ms"`
-	NumTurns     int     `json:"num_turns"`
-	Result       string  `json:"result"`
-	SessionID    string  `json:"session_id"`
+	Type         string   `json:"type"`
+	Subtype      string   `json:"subtype"`
+	TotalCostUSD float64  `json:"total_cost_usd"`
+	IsError      bool     `json:"is_error"`
+	DurationMS   int64    `json:"duration_ms"`
+	DurationAPI  int64    `json:"duration_api_ms"`
+	NumTurns     int      `json:"num_turns"`
+	Result       string   `json:"result"`
+	SessionID    string   `json:"session_id"`
+	Errors       []string `json:"errors"` // Error messages from Claude CLI
 }
 
 // SessionResult contains the results of a Claude session.
@@ -31,6 +34,7 @@ type SessionResult struct {
 	IsError   bool
 	RawJSON   []byte
 	Stderr    string
+	Errors    []string // Error messages from Claude CLI JSON output
 }
 
 // Config holds client configuration.
@@ -38,17 +42,20 @@ type Config struct {
 	SkipPermissions bool
 	WorkingDir      string
 	Prompt          string // Prompt for phase execution
+	Debug           bool   // Enable debug logging
 }
 
 // Client wraps the Claude Code CLI for programmatic access.
 type Client struct {
 	config Config
+	debug  *debug.Logger
 }
 
 // NewClient creates a new Claude client.
 func NewClient(config Config) *Client {
 	return &Client{
 		config: config,
+		debug:  debug.New(config.Debug, "claude"),
 	}
 }
 
@@ -85,6 +92,10 @@ func (c *Client) buildRunPhaseArgs(sessionID string, resume bool) []string {
 func (c *Client) RunPhase(sessionID string, resume bool) (*SessionResult, error) {
 	args := c.buildRunPhaseArgs(sessionID, resume)
 
+	// Debug: log command before execution
+	c.debug.LogSession(sessionID, resume, "starting")
+	c.debug.LogCmd("claude", args, c.config.WorkingDir)
+
 	cmd := exec.Command("claude", args...)
 	if c.config.WorkingDir != "" {
 		cmd.Dir = c.config.WorkingDir
@@ -94,7 +105,20 @@ func (c *Client) RunPhase(sessionID string, resume bool) (*SessionResult, error)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
+	startTime := time.Now()
 	err := cmd.Run()
+	duration := time.Since(startTime)
+
+	// Debug: log command result
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+	c.debug.LogCmdResult(exitCode, stdout.String(), stderr.String(), duration)
 
 	result := &SessionResult{
 		RawJSON: stdout.Bytes(),
@@ -104,17 +128,25 @@ func (c *Client) RunPhase(sessionID string, resume bool) (*SessionResult, error)
 	// Parse JSON output if available
 	if len(stdout.Bytes()) > 0 {
 		var parsed Result
-		if jsonErr := json.Unmarshal(stdout.Bytes(), &parsed); jsonErr == nil {
+		jsonErr := json.Unmarshal(stdout.Bytes(), &parsed)
+		c.debug.LogJSON(jsonErr == nil, jsonErr)
+		if jsonErr == nil {
 			result.SessionID = parsed.SessionID
 			result.Cost = parsed.TotalCostUSD
 			result.Duration = time.Duration(parsed.DurationMS) * time.Millisecond
 			result.NumTurns = parsed.NumTurns
 			result.Output = parsed.Result
 			result.IsError = parsed.IsError
+			result.Errors = parsed.Errors
+			c.debug.Log("Parsed result: session_id=%s cost=%.4f duration=%s turns=%d is_error=%v errors=%v",
+				result.SessionID, result.Cost, result.Duration, result.NumTurns, result.IsError, result.Errors)
 		}
+	} else {
+		c.debug.Log("No stdout to parse")
 	}
 
 	if err != nil {
+		c.debug.Log("Command failed: %v", err)
 		// Return the result with error information for classification
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			result.IsError = true
@@ -125,6 +157,7 @@ func (c *Client) RunPhase(sessionID string, resume bool) (*SessionResult, error)
 		return result, err
 	}
 
+	c.debug.LogSession(result.SessionID, resume, "completed")
 	return result, nil
 }
 
@@ -154,6 +187,14 @@ func (c *Client) RunCustomPromptWithSession(prompt, sessionID string, resume boo
 		args = append(args, "--dangerously-skip-permissions")
 	}
 
+	// Debug: log command before execution
+	if sessionID != "" {
+		c.debug.LogSession(sessionID, resume, "starting custom prompt")
+	} else {
+		c.debug.Log("Starting custom prompt (no session ID)")
+	}
+	c.debug.LogCmd("claude", args, c.config.WorkingDir)
+
 	cmd := exec.Command("claude", args...)
 	if c.config.WorkingDir != "" {
 		cmd.Dir = c.config.WorkingDir
@@ -163,7 +204,20 @@ func (c *Client) RunCustomPromptWithSession(prompt, sessionID string, resume boo
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
+	startTime := time.Now()
 	err := cmd.Run()
+	duration := time.Since(startTime)
+
+	// Debug: log command result
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+	c.debug.LogCmdResult(exitCode, stdout.String(), stderr.String(), duration)
 
 	result := &SessionResult{
 		RawJSON: stdout.Bytes(),
@@ -173,17 +227,25 @@ func (c *Client) RunCustomPromptWithSession(prompt, sessionID string, resume boo
 	// Parse JSON output if available
 	if len(stdout.Bytes()) > 0 {
 		var parsed Result
-		if jsonErr := json.Unmarshal(stdout.Bytes(), &parsed); jsonErr == nil {
+		jsonErr := json.Unmarshal(stdout.Bytes(), &parsed)
+		c.debug.LogJSON(jsonErr == nil, jsonErr)
+		if jsonErr == nil {
 			result.SessionID = parsed.SessionID
 			result.Cost = parsed.TotalCostUSD
 			result.Duration = time.Duration(parsed.DurationMS) * time.Millisecond
 			result.NumTurns = parsed.NumTurns
 			result.Output = parsed.Result
 			result.IsError = parsed.IsError
+			result.Errors = parsed.Errors
+			c.debug.Log("Parsed result: session_id=%s cost=%.4f duration=%s turns=%d is_error=%v errors=%v",
+				result.SessionID, result.Cost, result.Duration, result.NumTurns, result.IsError, result.Errors)
 		}
+	} else {
+		c.debug.Log("No stdout to parse")
 	}
 
 	if err != nil {
+		c.debug.Log("Custom prompt command failed: %v", err)
 		result.IsError = true
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if result.Stderr == "" {
@@ -193,5 +255,6 @@ func (c *Client) RunCustomPromptWithSession(prompt, sessionID string, resume boo
 		return result, err
 	}
 
+	c.debug.LogSession(result.SessionID, resume, "custom prompt completed")
 	return result, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	ContinueSession bool
 	ServePort       int
 	ServeBind       string
+	Debug           bool // Enable debug logging for troubleshooting
 
 	// postCommandExplicit tracks whether post-command was explicitly set in config.
 	// This allows distinguishing "not set" (use default) from "set to empty" (disabled).
@@ -58,6 +59,7 @@ func Load(workingDir string) *Config {
 	v.SetDefault("continue-session", true)
 	v.SetDefault("serve-port", DefaultServePort)
 	v.SetDefault("serve-bind", DefaultServeBind)
+	v.SetDefault("debug", false)
 
 	// Config file name (without extension)
 	v.SetConfigName(".orbit")
@@ -115,6 +117,7 @@ func Load(workingDir string) *Config {
 	continueSession := v.GetBool("continue-session")
 	servePort := v.GetInt("serve-port")
 	serveBind := v.GetString("serve-bind")
+	debug := v.GetBool("debug")
 
 	// Apply environment variable overrides (highest priority)
 	// Using os.LookupEnv to detect both set values and explicitly empty values
@@ -140,6 +143,9 @@ func Load(workingDir string) *Config {
 	if envServeBind, exists := os.LookupEnv("ORBIT_SERVE_BIND"); exists {
 		serveBind = envServeBind
 	}
+	if envDebug, exists := os.LookupEnv("ORBIT_DEBUG"); exists {
+		debug = envDebug == "true" || envDebug == "1"
+	}
 
 	return &Config{
 		Command:             command,
@@ -148,6 +154,7 @@ func Load(workingDir string) *Config {
 		ContinueSession:     continueSession,
 		ServePort:           servePort,
 		ServeBind:           serveBind,
+		Debug:               debug,
 		postCommandExplicit: postCommandExplicit,
 	}
 }

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,0 +1,132 @@
+// Package debug provides debug logging utilities for Orbit.
+package debug
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+)
+
+// Logger provides conditional debug logging.
+type Logger struct {
+	enabled bool
+	prefix  string
+}
+
+// New creates a new debug logger.
+func New(enabled bool, prefix string) *Logger {
+	return &Logger{
+		enabled: enabled,
+		prefix:  prefix,
+	}
+}
+
+// Enabled returns whether debug logging is enabled.
+func (l *Logger) Enabled() bool {
+	if l == nil {
+		return false
+	}
+	return l.enabled
+}
+
+// Log logs a debug message if debug mode is enabled.
+func (l *Logger) Log(format string, args ...any) {
+	if l == nil || !l.enabled {
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	if l.prefix != "" {
+		log.Printf("[DEBUG:%s] %s", l.prefix, msg)
+	} else {
+		log.Printf("[DEBUG] %s", msg)
+	}
+}
+
+// LogCmd logs command execution details.
+func (l *Logger) LogCmd(name string, args []string, workingDir string) {
+	if l == nil || !l.enabled {
+		return
+	}
+	cmd := name + " " + strings.Join(args, " ")
+	l.Log("Executing: %s", cmd)
+	if workingDir != "" {
+		l.Log("Working dir: %s", workingDir)
+	}
+}
+
+// LogCmdResult logs the result of a command execution.
+func (l *Logger) LogCmdResult(exitCode int, stdout, stderr string, duration time.Duration) {
+	if l == nil || !l.enabled {
+		return
+	}
+	l.Log("Exit code: %d (duration: %s)", exitCode, duration)
+	if len(stdout) > 0 {
+		preview := truncate(stdout, 500)
+		l.Log("Stdout (%d bytes): %s", len(stdout), preview)
+	} else {
+		l.Log("Stdout: (empty)")
+	}
+	if len(stderr) > 0 {
+		preview := truncate(stderr, 500)
+		l.Log("Stderr (%d bytes): %s", len(stderr), preview)
+	}
+}
+
+// LogJSON logs JSON parsing results.
+func (l *Logger) LogJSON(success bool, parseErr error) {
+	if l == nil || !l.enabled {
+		return
+	}
+	if success {
+		l.Log("JSON parsed successfully")
+	} else {
+		l.Log("JSON parse failed: %v", parseErr)
+	}
+}
+
+// LogSession logs session-related information.
+func (l *Logger) LogSession(sessionID string, isResume bool, action string) {
+	if l == nil || !l.enabled {
+		return
+	}
+	mode := "new"
+	if isResume {
+		mode = "resume"
+	}
+	l.Log("Session %s: id=%s mode=%s", action, sessionID, mode)
+}
+
+// LogRetry logs retry-related information.
+func (l *Logger) LogRetry(attempt, maxAttempts int, errType, waitDuration string) {
+	if l == nil || !l.enabled {
+		return
+	}
+	l.Log("Retry %d/%d: error_type=%s wait=%s", attempt, maxAttempts, errType, waitDuration)
+}
+
+// LogConfig logs configuration values.
+func (l *Logger) LogConfig(key string, value any) {
+	if l == nil || !l.enabled {
+		return
+	}
+	l.Log("Config %s = %v", key, value)
+}
+
+// LogError logs error classification details.
+func (l *Logger) LogError(errType string, message string, retryable bool) {
+	if l == nil || !l.enabled {
+		return
+	}
+	l.Log("Error classified: type=%s retryable=%v message=%s", errType, retryable, truncate(message, 200))
+}
+
+// truncate shortens a string to the given max length.
+func truncate(s string, maxLen int) string {
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	s = strings.ReplaceAll(s, "\r", "\\r")
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -50,8 +50,10 @@ func (e *ClassifiedError) Unwrap() error {
 }
 
 // Classify examines error output and classifies it by type.
-func Classify(exitCode int, stderr, stdout string) *ClassifiedError {
-	combined := strings.ToLower(stderr + stdout)
+// The errMsgs parameter contains error messages from Claude's JSON output.
+func Classify(exitCode int, stderr, stdout string, errMsgs []string) *ClassifiedError {
+	// Combine all error sources for pattern matching
+	combined := strings.ToLower(stderr + stdout + strings.Join(errMsgs, " "))
 
 	// Check for rate limiting
 	if strings.Contains(combined, "rate limit") ||
@@ -91,8 +93,11 @@ func Classify(exitCode int, stderr, stdout string) *ClassifiedError {
 		}
 	}
 
-	// Unknown error
-	msg := stderr
+	// Unknown error - prefer error messages from JSON, then stderr, then stdout
+	msg := strings.Join(errMsgs, "; ")
+	if msg == "" {
+		msg = stderr
+	}
 	if msg == "" {
 		msg = stdout
 	}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -72,7 +72,36 @@ func TestClassify(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := Classify(tc.exitCode, tc.stderr, tc.stdout)
+			got := Classify(tc.exitCode, tc.stderr, tc.stdout, nil)
+			if got.Type != tc.wantType {
+				t.Errorf("got type %v, want %v", got.Type, tc.wantType)
+			}
+		})
+	}
+}
+
+func TestClassify_WithErrors(t *testing.T) {
+	tests := map[string]struct {
+		errors   []string
+		wantType ErrorType
+	}{
+		"streaming mode error": {
+			errors:   []string{"only prompt commands are supported in streaming mode"},
+			wantType: ErrUnknown, // Currently not classified as retryable
+		},
+		"rate limit in errors": {
+			errors:   []string{"rate limit exceeded"},
+			wantType: ErrRateLimit,
+		},
+		"connection in errors": {
+			errors:   []string{"connection refused"},
+			wantType: ErrConnection,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Classify(1, "", "", tc.errors)
 			if got.Type != tc.wantType {
 				t.Errorf("got type %v, want %v", got.Type, tc.wantType)
 			}

--- a/internal/orbit/orbit.go
+++ b/internal/orbit/orbit.go
@@ -13,6 +13,7 @@ import (
 
 	output "github.com/ArjenSchwarz/go-output/v2"
 	"github.com/arjenschwarz/orbit/internal/claude"
+	"github.com/arjenschwarz/orbit/internal/debug"
 	"github.com/arjenschwarz/orbit/internal/display"
 	orberrors "github.com/arjenschwarz/orbit/internal/errors"
 	"github.com/arjenschwarz/orbit/internal/logs"
@@ -41,6 +42,7 @@ type Config struct {
 	SkipPermissions bool
 	Verbose         bool
 	DryRun          bool
+	Debug           bool   // Enable debug logging for troubleshooting
 	WorkingDir      string
 	Command         string // Custom phase command
 	PostCommand     string // Post-completion command (empty = disabled)
@@ -50,28 +52,49 @@ type Config struct {
 
 // Orbit orchestrates Claude Code sessions to implement spec phases.
 type Orbit struct {
-	config              Config
-	runeClient          *rune.Client
-	claudeClient        claudeRunner
-	logManager          *logs.Manager
-	phaseSummaries      []rune.PhaseSummary
-	spinner             *display.Spinner
-	shutdownCtx         context.Context
-	shutdownCancel      context.CancelFunc
-	registry            *registry.Registry // Web interface run registry
-	runID               string             // UUID of the current run in registry
-	currentPhaseRunCount int               // Track retry count for current phase
+	config               Config
+	runeClient           *rune.Client
+	claudeClient         claudeRunner
+	logManager           *logs.Manager
+	phaseSummaries       []rune.PhaseSummary
+	spinner              *display.Spinner
+	shutdownCtx          context.Context
+	shutdownCancel       context.CancelFunc
+	registry             *registry.Registry // Web interface run registry
+	runID                string             // UUID of the current run in registry
+	currentPhaseRunCount int                // Track retry count for current phase
+	debug                *debug.Logger      // Debug logger
 }
 
 // New creates a new Orbit instance.
 func New(config Config) (*Orbit, error) {
+	// Create debug logger
+	dbg := debug.New(config.Debug, "orbit")
+
 	runeClient := rune.NewClient(config.TasksFile)
+	runeClient.SetDebug(config.Debug)
 
 	claudeClient := claude.NewClient(claude.Config{
 		SkipPermissions: config.SkipPermissions,
 		WorkingDir:      config.WorkingDir,
 		Prompt:          config.Command,
+		Debug:           config.Debug,
 	})
+
+	// Log configuration if debug enabled
+	if config.Debug {
+		dbg.LogConfig("TasksFile", config.TasksFile)
+		dbg.LogConfig("LogDir", config.LogDir)
+		dbg.LogConfig("BranchName", config.BranchName)
+		dbg.LogConfig("SkipPermissions", config.SkipPermissions)
+		dbg.LogConfig("Verbose", config.Verbose)
+		dbg.LogConfig("DryRun", config.DryRun)
+		dbg.LogConfig("WorkingDir", config.WorkingDir)
+		dbg.LogConfig("Command", config.Command)
+		dbg.LogConfig("PostCommand", config.PostCommand)
+		dbg.LogConfig("DateSubdirs", config.DateSubdirs)
+		dbg.LogConfig("ContinueSession", config.ContinueSession)
+	}
 
 	var logManager *logs.Manager
 	if !config.DryRun {
@@ -124,6 +147,7 @@ func New(config Config) (*Orbit, error) {
 		shutdownCtx:    ctx,
 		shutdownCancel: cancel,
 		registry:       reg,
+		debug:          dbg,
 	}, nil
 }
 
@@ -160,15 +184,19 @@ func (o *Orbit) Run() error {
 		// Check for shutdown signal between phases
 		select {
 		case <-o.shutdownCtx.Done():
+			o.debug.Log("Shutdown signal received")
 			return o.fail(fmt.Errorf("interrupted by user"))
 		default:
 		}
 
 		// Check for remaining tasks
+		o.debug.Log("Checking for pending tasks...")
 		pending, err := o.runeClient.ListPending()
 		if err != nil {
+			o.debug.Log("Failed to list pending tasks: %v", err)
 			return o.fail(fmt.Errorf("failed to check pending tasks: %w", err))
 		}
+		o.debug.Log("Found %d pending tasks", len(pending))
 
 		if len(pending) == 0 {
 			log.Println("All tasks complete!")
@@ -176,10 +204,13 @@ func (o *Orbit) Run() error {
 		}
 
 		// Get the next phase info
+		o.debug.Log("Getting next phase...")
 		nextPhase, err := o.runeClient.GetNextPhase()
 		if err != nil {
+			o.debug.Log("Failed to get next phase: %v", err)
 			return o.fail(fmt.Errorf("failed to get next phase: %w", err))
 		}
+		o.debug.Log("Next phase: name=%s tasks=%d all_complete=%v", nextPhase.PhaseName, len(nextPhase.Tasks), nextPhase.AllComplete)
 
 		if nextPhase.AllComplete {
 			log.Println("All phases complete!")
@@ -303,29 +334,38 @@ func (o *Orbit) runPhaseWithRetry(phase int) error {
 	var lastErr error
 	o.currentPhaseRunCount = 0
 
+	o.debug.Log("Starting phase %d with up to %d retries", phase, maxRetries)
+
 	for attempt := range maxRetries {
 		o.currentPhaseRunCount++
+		o.debug.Log("Phase %d attempt %d/%d", phase, attempt+1, maxRetries)
 
 		// Update phase status to running (req 3.5)
 		o.updatePhaseStatus(phase, registry.PhaseStatusRunning, o.currentPhaseRunCount)
 
 		err := o.runPhase(phase)
 		if err == nil {
+			o.debug.Log("Phase %d completed successfully on attempt %d", phase, attempt+1)
 			// Update phase status to completed (req 3.6)
 			o.updatePhaseStatus(phase, registry.PhaseStatusCompleted, o.currentPhaseRunCount)
 			return nil
 		}
 
+		o.debug.Log("Phase %d attempt %d failed: %v", phase, attempt+1, err)
+
 		// Classify the error
 		classified, ok := err.(*orberrors.ClassifiedError)
 		if !ok {
+			o.debug.Log("Error is not a ClassifiedError, not retrying: %T", err)
 			// Unknown error type, don't retry
 			return err
 		}
 
+		o.debug.LogError(classified.Type.String(), classified.Message, classified.Type.IsRetryable())
 		lastErr = err
 
 		if !classified.Type.IsRetryable() {
+			o.debug.Log("Error type %s is not retryable, stopping", classified.Type)
 			// Non-retryable error
 			return err
 		}
@@ -357,6 +397,8 @@ func (o *Orbit) runPhaseWithRetry(phase int) error {
 			waitTime = orberrors.BackoffDuration(attempt)
 		}
 
+		o.debug.LogRetry(attempt+1, maxRetries, classified.Type.String(), waitTime.String())
+
 		// Resume spinner with wait countdown during retry wait
 		if o.spinner != nil {
 			o.spinner.UpdateWait(waitTime)
@@ -371,6 +413,7 @@ func (o *Orbit) runPhaseWithRetry(phase int) error {
 		}
 	}
 
+	o.debug.Log("Phase %d failed after %d attempts", phase, maxRetries)
 	// Update phase status to failed after max retries (req 3.6)
 	o.updatePhaseStatus(phase, registry.PhaseStatusFailed, o.currentPhaseRunCount)
 
@@ -380,6 +423,7 @@ func (o *Orbit) runPhaseWithRetry(phase int) error {
 // runPhase executes a single phase.
 func (o *Orbit) runPhase(phase int) error {
 	startTime := time.Now()
+	o.debug.Log("runPhase(%d) starting", phase)
 
 	// Start spinner before Claude execution
 	if o.spinner != nil {
@@ -393,14 +437,19 @@ func (o *Orbit) runPhase(phase int) error {
 		var err error
 		sessionID, isResume, err = o.logManager.StartPhase(phase, o.config.ContinueSession)
 		if err != nil {
+			o.debug.Log("Failed to start phase in log manager: %v", err)
 			return o.fail(fmt.Errorf("failed to start phase: %w", err))
 		}
+		o.debug.LogSession(sessionID, isResume, "obtained from log manager")
 	} else {
 		sessionID = uuid.NewString()
 		isResume = false
+		o.debug.LogSession(sessionID, isResume, "generated new (no log manager)")
 	}
 
+	o.debug.Log("Executing Claude for phase %d...", phase)
 	result, err := o.claudeClient.RunPhase(sessionID, isResume)
+	o.debug.Log("Claude execution completed: err=%v", err)
 
 	// Stop spinner after Claude returns
 	if o.spinner != nil {
@@ -409,38 +458,51 @@ func (o *Orbit) runPhase(phase int) error {
 
 	// Handle resume failure (req 3.7-3.9)
 	if err != nil && isResume && isSessionInvalidError(result) {
+		o.debug.Log("Session resume failed, detected invalid session error")
 		log.Printf("Warning: Session resume failed, starting fresh session")
 		sessionID = uuid.NewString()
+		o.debug.LogSession(sessionID, false, "retrying with fresh session")
 		if o.logManager != nil {
 			if setErr := o.logManager.SetCurrentPhaseSessionID(sessionID); setErr != nil {
 				log.Printf("Warning: failed to update session ID: %v", setErr)
+				o.debug.Log("Failed to update session ID in log manager: %v", setErr)
 			}
 		}
 		result, err = o.claudeClient.RunPhase(sessionID, false)
+		o.debug.Log("Fresh session execution completed: err=%v", err)
 	}
 
 	if err != nil {
+		o.debug.Log("Phase execution failed: %v", err)
+
 		// Save the failed session for debugging
 		if o.logManager != nil && result != nil {
+			o.debug.Log("Saving failed session for debugging")
 			_ = o.logManager.SaveSession(phase, result, startTime)
 		}
 
 		// Classify and return the error
-		classified := orberrors.Classify(1, result.Stderr, result.Output)
+		o.debug.Log("Classifying error from stderr=%d bytes, output=%d bytes, errors=%v",
+			len(result.Stderr), len(result.Output), result.Errors)
+		classified := orberrors.Classify(1, result.Stderr, result.Output, result.Errors)
+		o.debug.LogError(classified.Type.String(), classified.Message, classified.Type.IsRetryable())
 		return classified
 	}
 
 	// Reconcile session ID if Claude returned a different one (req 2.5, 2.6)
 	if o.logManager != nil && result.SessionID != sessionID {
+		o.debug.Log("Session ID changed: expected=%s got=%s", sessionID, result.SessionID)
 		o.logManager.ReconcileSessionID(result.SessionID)
 	}
 
 	// Check if Claude reported an error in its output
 	if result.IsError {
+		o.debug.Log("Claude reported error in output (IsError=true)")
 		if o.logManager != nil {
 			_ = o.logManager.SaveSession(phase, result, startTime)
 		}
-		classified := orberrors.Classify(1, result.Stderr, result.Output)
+		classified := orberrors.Classify(1, result.Stderr, result.Output, result.Errors)
+		o.debug.LogError(classified.Type.String(), classified.Message, classified.Type.IsRetryable())
 		return classified
 	}
 
@@ -448,12 +510,17 @@ func (o *Orbit) runPhase(phase int) error {
 	if o.logManager != nil {
 		if err := o.logManager.SaveSession(phase, result, startTime); err != nil {
 			log.Printf("Warning: failed to save session log: %v", err)
+			o.debug.Log("Failed to save session log: %v", err)
 		}
 		// Complete phase (req 2.7)
 		if err := o.logManager.CompletePhase(); err != nil {
 			log.Printf("Warning: failed to complete phase: %v", err)
+			o.debug.Log("Failed to complete phase in log manager: %v", err)
 		}
 	}
+
+	o.debug.Log("Phase %d completed successfully: cost=$%.4f duration=%s turns=%d",
+		phase, result.Cost, result.Duration, result.NumTurns)
 
 	if o.config.Verbose {
 		log.Printf("Phase %d: cost=$%.4f, duration=%s, turns=%d",
@@ -466,6 +533,7 @@ func (o *Orbit) runPhase(phase int) error {
 // runPostCommand executes the post-completion command.
 func (o *Orbit) runPostCommand() error {
 	startTime := time.Now()
+	o.debug.Log("runPostCommand starting")
 
 	// Start spinner for post-completion
 	if o.spinner != nil {
@@ -479,11 +547,15 @@ func (o *Orbit) runPostCommand() error {
 		var err error
 		sessionID, isResume, err = o.logManager.StartPostCompletion(o.config.ContinueSession)
 		if err != nil {
+			o.debug.Log("Failed to start post-completion in log manager: %v", err)
 			return o.fail(fmt.Errorf("failed to start post-completion: %w", err))
 		}
+		o.debug.LogSession(sessionID, isResume, "post-completion obtained from log manager")
 	}
 
+	o.debug.Log("Executing post-completion command...")
 	result, err := o.claudeClient.RunCustomPromptWithSession(o.config.PostCommand, sessionID, isResume)
+	o.debug.Log("Post-completion execution completed: err=%v", err)
 
 	// Stop spinner after Claude returns
 	if o.spinner != nil {
@@ -492,36 +564,46 @@ func (o *Orbit) runPostCommand() error {
 
 	// Handle resume failure
 	if err != nil && isResume && isSessionInvalidError(result) {
+		o.debug.Log("Post-completion session resume failed, detected invalid session error")
 		log.Printf("Warning: Post-completion session resume failed, starting fresh session")
 		sessionID = uuid.NewString()
+		o.debug.LogSession(sessionID, false, "post-completion retrying with fresh session")
 		if o.logManager != nil {
 			if setErr := o.logManager.SetPostCompletionSessionID(sessionID); setErr != nil {
 				log.Printf("Warning: failed to update post-completion session ID: %v", setErr)
+				o.debug.Log("Failed to update post-completion session ID: %v", setErr)
 			}
 		}
 		result, err = o.claudeClient.RunCustomPromptWithSession(o.config.PostCommand, sessionID, false)
+		o.debug.Log("Fresh post-completion execution completed: err=%v", err)
 	}
 
 	if err != nil {
+		o.debug.Log("Post-completion execution failed: %v", err)
 		// Save the failed session for debugging
 		if o.logManager != nil && result != nil {
+			o.debug.Log("Saving failed post-completion session for debugging")
 			_ = o.logManager.SavePostCompletionSession(result, startTime)
 		}
-		classified := orberrors.Classify(1, result.Stderr, result.Output)
+		classified := orberrors.Classify(1, result.Stderr, result.Output, result.Errors)
+		o.debug.LogError(classified.Type.String(), classified.Message, classified.Type.IsRetryable())
 		return classified
 	}
 
 	// Reconcile session ID if Claude returned a different one
 	if o.logManager != nil && result.SessionID != sessionID {
+		o.debug.Log("Post-completion session ID changed: expected=%s got=%s", sessionID, result.SessionID)
 		o.logManager.ReconcilePostCompletionSessionID(result.SessionID)
 	}
 
 	// Check if Claude reported an error in its output
 	if result.IsError {
+		o.debug.Log("Claude reported error in post-completion output (IsError=true)")
 		if o.logManager != nil {
 			_ = o.logManager.SavePostCompletionSession(result, startTime)
 		}
-		classified := orberrors.Classify(1, result.Stderr, result.Output)
+		classified := orberrors.Classify(1, result.Stderr, result.Output, result.Errors)
+		o.debug.LogError(classified.Type.String(), classified.Message, classified.Type.IsRetryable())
 		return classified
 	}
 
@@ -529,12 +611,17 @@ func (o *Orbit) runPostCommand() error {
 	if o.logManager != nil {
 		if err := o.logManager.SavePostCompletionSession(result, startTime); err != nil {
 			log.Printf("Warning: failed to save post-completion log: %v", err)
+			o.debug.Log("Failed to save post-completion log: %v", err)
 		}
 		// Complete post-completion
 		if err := o.logManager.CompletePostCompletion(); err != nil {
 			log.Printf("Warning: failed to complete post-completion: %v", err)
+			o.debug.Log("Failed to complete post-completion in log manager: %v", err)
 		}
 	}
+
+	o.debug.Log("Post-completion completed successfully: cost=$%.4f duration=%s turns=%d",
+		result.Cost, result.Duration, result.NumTurns)
 
 	if o.config.Verbose {
 		log.Printf("Post-completion: cost=$%.4f, duration=%s, turns=%d",

--- a/internal/orbit/orbit_test.go
+++ b/internal/orbit/orbit_test.go
@@ -478,7 +478,7 @@ func TestErrorClassification_IsUsedCorrectly(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			classified := orberrors.Classify(1, tc.stderr, "")
+			classified := orberrors.Classify(1, tc.stderr, "", nil)
 			if classified.Type != tc.wantType {
 				t.Errorf("type: got %v, want %v", classified.Type, tc.wantType)
 			}

--- a/internal/rune/client.go
+++ b/internal/rune/client.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/arjenschwarz/orbit/internal/debug"
 )
 
 // Status represents a task's completion status.
@@ -75,13 +78,20 @@ type PhaseSummary struct {
 // Client wraps the rune CLI for programmatic access.
 type Client struct {
 	tasksFile string
+	debug     *debug.Logger
 }
 
 // NewClient creates a new rune client.
 func NewClient(tasksFile string) *Client {
 	return &Client{
 		tasksFile: tasksFile,
+		debug:     debug.New(false, "rune"),
 	}
+}
+
+// SetDebug enables or disables debug logging.
+func (c *Client) SetDebug(enabled bool) {
+	c.debug = debug.New(enabled, "rune")
 }
 
 // TasksFile returns the configured tasks file path.
@@ -92,26 +102,46 @@ func (c *Client) TasksFile() string {
 // ListPending returns all pending (incomplete) tasks.
 func (c *Client) ListPending() ([]Task, error) {
 	args := []string{"list", c.tasksFile, "--filter", "pending", "--format", "json"}
-	cmd := exec.Command("rune", args...)
 
+	c.debug.LogCmd("rune", args, "")
+
+	startTime := time.Now()
+	cmd := exec.Command("rune", args...)
 	output, err := cmd.Output()
+	duration := time.Since(startTime)
+
 	if err != nil {
+		exitCode := -1
+		stderr := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+			stderr = string(exitErr.Stderr)
+		}
+		c.debug.LogCmdResult(exitCode, string(output), stderr, duration)
+		c.debug.Log("ListPending failed: %v", err)
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("rune list failed: %s", string(exitErr.Stderr))
 		}
 		return nil, fmt.Errorf("rune list failed: %w", err)
 	}
 
+	c.debug.LogCmdResult(0, string(output), "", duration)
+
 	// Handle empty output (no pending tasks)
 	trimmed := strings.TrimSpace(string(output))
 	if trimmed == "" || trimmed == "[]" || trimmed == "null" {
+		c.debug.Log("ListPending: no pending tasks (empty output)")
 		return []Task{}, nil
 	}
 
 	var result ListResult
 	if err := json.Unmarshal(output, &result); err != nil {
+		c.debug.LogJSON(false, err)
 		return nil, fmt.Errorf("failed to parse rune output: %w", err)
 	}
+
+	c.debug.LogJSON(true, nil)
+	c.debug.Log("ListPending: found %d pending tasks", len(result.Tasks))
 
 	return result.Tasks, nil
 }
@@ -119,32 +149,55 @@ func (c *Client) ListPending() ([]Task, error) {
 // GetNextPhase returns the next incomplete phase with all its tasks.
 func (c *Client) GetNextPhase() (*NextPhaseResult, error) {
 	args := []string{"next", c.tasksFile, "--phase", "--format", "json"}
-	cmd := exec.Command("rune", args...)
 
+	c.debug.LogCmd("rune", args, "")
+
+	startTime := time.Now()
+	cmd := exec.Command("rune", args...)
 	output, err := cmd.Output()
+	duration := time.Since(startTime)
+
 	if err != nil {
+		exitCode := -1
+		stderr := ""
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			stderr := string(exitErr.Stderr)
+			exitCode = exitErr.ExitCode()
+			stderr = string(exitErr.Stderr)
+		}
+		c.debug.LogCmdResult(exitCode, string(output), stderr, duration)
+
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderrStr := string(exitErr.Stderr)
 			// Check if this is "all tasks complete" message
-			if strings.Contains(strings.ToLower(stderr), "complete") ||
-				strings.Contains(strings.ToLower(stderr), "no tasks") {
+			if strings.Contains(strings.ToLower(stderrStr), "complete") ||
+				strings.Contains(strings.ToLower(stderrStr), "no tasks") {
+				c.debug.Log("GetNextPhase: all tasks complete (detected from stderr)")
 				return &NextPhaseResult{AllComplete: true}, nil
 			}
-			return nil, fmt.Errorf("rune next failed: %s", stderr)
+			c.debug.Log("GetNextPhase failed: %s", stderrStr)
+			return nil, fmt.Errorf("rune next failed: %s", stderrStr)
 		}
+		c.debug.Log("GetNextPhase failed: %v", err)
 		return nil, fmt.Errorf("rune next failed: %w", err)
 	}
+
+	c.debug.LogCmdResult(0, string(output), "", duration)
 
 	// Handle empty output
 	trimmed := strings.TrimSpace(string(output))
 	if trimmed == "" || trimmed == "null" {
+		c.debug.Log("GetNextPhase: all tasks complete (empty output)")
 		return &NextPhaseResult{AllComplete: true}, nil
 	}
 
 	var result NextPhaseResult
 	if err := json.Unmarshal(output, &result); err != nil {
+		c.debug.LogJSON(false, err)
 		return nil, fmt.Errorf("failed to parse rune output: %w", err)
 	}
+
+	c.debug.LogJSON(true, nil)
+	c.debug.Log("GetNextPhase: phase=%s tasks=%d", result.PhaseName, len(result.Tasks))
 
 	return &result, nil
 }
@@ -184,25 +237,46 @@ func (c *Client) GetCurrentPhaseNumber() (int, error) {
 // ListAll returns all tasks regardless of status.
 func (c *Client) ListAll() ([]Task, error) {
 	args := []string{"list", c.tasksFile, "--format", "json"}
-	cmd := exec.Command("rune", args...)
 
+	c.debug.LogCmd("rune", args, "")
+
+	startTime := time.Now()
+	cmd := exec.Command("rune", args...)
 	output, err := cmd.Output()
+	duration := time.Since(startTime)
+
 	if err != nil {
+		exitCode := -1
+		stderr := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+			stderr = string(exitErr.Stderr)
+		}
+		c.debug.LogCmdResult(exitCode, string(output), stderr, duration)
+		c.debug.Log("ListAll failed: %v", err)
+
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("rune list failed: %s", string(exitErr.Stderr))
 		}
 		return nil, fmt.Errorf("rune list failed: %w", err)
 	}
 
+	c.debug.LogCmdResult(0, string(output), "", duration)
+
 	trimmed := strings.TrimSpace(string(output))
 	if trimmed == "" || trimmed == "[]" || trimmed == "null" {
+		c.debug.Log("ListAll: no tasks (empty output)")
 		return []Task{}, nil
 	}
 
 	var result ListResult
 	if err := json.Unmarshal(output, &result); err != nil {
+		c.debug.LogJSON(false, err)
 		return nil, fmt.Errorf("failed to parse rune output: %w", err)
 	}
+
+	c.debug.LogJSON(true, nil)
+	c.debug.Log("ListAll: found %d tasks", len(result.Tasks))
 
 	return result.Tasks, nil
 }


### PR DESCRIPTION
## Summary

- Add `--debug` flag to enable detailed logging during orbit runs
- Create debug logger utility (`internal/debug`) with structured logging methods
- Add debug output to Claude client, rune client, and orbit orchestration
- Capture `errors` array from Claude CLI JSON output for better error messages

## Details

Debug logging helps diagnose issues by showing:
- Full CLI commands being executed
- Exit codes, stdout/stderr content (truncated previews)
- Session ID tracking and resume/new mode decisions
- Error classification results and retry decisions
- Configuration values at startup

Debug mode can be enabled via:
- CLI flag: `orbit run --debug`
- Environment variable: `ORBIT_DEBUG=true`
- Config file: `debug: true` in `.orbit.yaml`

## Test plan

- [x] Run `make lint` - passes
- [x] Run `make test` - all tests pass
- [ ] Manual test with `orbit run --debug` to verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)