### PR TITLE
Fix registry path handling and transcript parsing issues

### DIFF
--- a/internal/logs/manager.go
+++ b/internal/logs/manager.go
@@ -152,6 +152,11 @@ func (m *Manager) SessionDir() string {
 	return m.sessionDir
 }
 
+// RunNumber returns the current run number for file naming purposes.
+func (m *Manager) RunNumber() int {
+	return m.summary.RunNumber
+}
+
 // loadExistingSummary loads an existing summary.json from the session directory.
 func (m *Manager) loadExistingSummary() error {
 	path := filepath.Join(m.sessionDir, "summary.json")

--- a/internal/orbit/orbit.go
+++ b/internal/orbit/orbit.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -756,11 +757,25 @@ func (o *Orbit) registerRun() (string, error) {
 	entry.Status = registry.StatusRunning
 	entry.StartedAt = time.Now()
 
-	// Set log directory
+	// Set log directory (convert to absolute path for web interface access)
+	var logDir string
 	if o.logManager != nil {
-		entry.LogDir = o.logManager.SessionDir()
+		logDir = o.logManager.SessionDir()
 	} else {
-		entry.LogDir = o.config.LogDir
+		logDir = o.config.LogDir
+	}
+	absLogDir, err := filepath.Abs(logDir)
+	if err != nil {
+		log.Printf("Warning: failed to get absolute path for log dir: %v", err)
+		absLogDir = logDir // Fall back to original
+	}
+	entry.LogDir = absLogDir
+
+	// Set run number for file naming (defaults to 1 if no log manager)
+	if o.logManager != nil {
+		entry.RunNumber = o.logManager.RunNumber()
+	} else {
+		entry.RunNumber = 1
 	}
 
 	// Set PID for auto-registered runs

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -46,6 +46,7 @@ type RunEntry struct {
 	Branch        string     `json:"branch"`
 	PID           *int       `json:"pid,omitempty"`
 	Phases        []Phase    `json:"phases,omitempty"`
+	RunNumber     int        `json:"run_number,omitempty"` // Orbit run number for file naming (1 = first run)
 }
 
 // NewRunEntry creates a new RunEntry with default values.

--- a/internal/transcript/parser.go
+++ b/internal/transcript/parser.go
@@ -28,6 +28,12 @@ var codexTypes = map[string]bool{
 	"turn_context":  true,
 }
 
+// infrastructureTypes are entry types that should be skipped during format detection.
+// These are internal Claude infrastructure entries, not part of the conversation.
+var infrastructureTypes = map[string]bool{
+	"queue-operation": true,
+}
+
 // DetectFormat examines the first non-empty line to determine the log format.
 // Returns the detected format, the first line bytes (with BOM stripped), and any error.
 // The first line is returned to allow reuse without re-reading.
@@ -133,27 +139,59 @@ type ParseWarning struct {
 func ParseJSONL(r io.Reader) (*ParseResult, error) {
 	bufReader := bufio.NewReader(r)
 
-	// Read first line for format detection (preserves streaming)
-	// Using readFirstNonEmptyLineFromBufReader directly to preserve reader position
-	firstLine, err := readFirstNonEmptyLineFromBufReader(bufReader)
-	if err != nil {
-		if errors.Is(err, io.EOF) {
-			return nil, fmt.Errorf("empty file")
+	// Collect lines for format detection, skipping infrastructure entries
+	var collectedLines [][]byte
+	var format Format
+	var formatErr error
+
+	for {
+		line, err := readFirstNonEmptyLineFromBufReader(bufReader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				if len(collectedLines) == 0 {
+					return nil, fmt.Errorf("empty file")
+				}
+				return nil, fmt.Errorf("no recognizable format entries found")
+			}
+			return nil, fmt.Errorf("failed to read line: %w", err)
 		}
-		return nil, fmt.Errorf("failed to read first line: %w", err)
+
+		// Strip BOM if present (only relevant for first line)
+		if len(collectedLines) == 0 {
+			line = stripBOM(line)
+		}
+
+		collectedLines = append(collectedLines, line)
+
+		// Try to detect format from this line
+		format, formatErr = detectFormatFromLine(line)
+		if formatErr == nil {
+			// Found a recognizable format
+			break
+		}
+
+		// Check if this is an infrastructure type we should skip
+		var obj struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(line, &obj) == nil && infrastructureTypes[obj.Type] {
+			// Skip infrastructure entries and keep looking
+			continue
+		}
+
+		// Unknown type that's not infrastructure - fail
+		return nil, formatErr
 	}
 
-	// Strip BOM if present
-	firstLine = stripBOM(firstLine)
-
-	// Detect format from first line
-	format, err := detectFormatFromLine(firstLine)
-	if err != nil {
-		return nil, err
+	// Reconstruct collected lines for the parser
+	var linesBuf bytes.Buffer
+	for _, line := range collectedLines {
+		linesBuf.Write(line)
+		linesBuf.WriteByte('\n')
 	}
 
-	// Combine first line with remaining content for streaming parse
-	combined := io.MultiReader(bytes.NewReader(append(firstLine, '\n')), bufReader)
+	// Combine collected lines with remaining content for streaming parse
+	combined := io.MultiReader(&linesBuf, bufReader)
 
 	// Delegate to appropriate parser
 	switch format {
@@ -199,7 +237,7 @@ func parseClaudeJSONL(r io.Reader) (*ParseResult, error) {
 		}
 
 		// Only process known entry types (user, assistant)
-		// Skip unknown types silently per requirement 4.7
+		// Skip infrastructure types (queue-operation) and unknown types silently
 		if entry.Type != "user" && entry.Type != "assistant" {
 			continue
 		}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -323,19 +323,22 @@ func (s *Server) hasPostCompletionTranscript(logDir string) bool {
 }
 
 // findPostCompletionTranscript finds the post-completion transcript file.
+// File naming convention follows logs/manager.go:
+// - Run 1: post-completion-session-transcript.jsonl
+// - Run 2+: post-completion-run-N-session-transcript.jsonl
 func (s *Server) findPostCompletionTranscript(logDir string, runNumber int) string {
-	// Try run-specific file first
 	if runNumber > 1 {
+		// Run 2+ uses numbered format
 		runPath := filepath.Join(logDir, fmt.Sprintf("post-completion-run-%d-session-transcript.jsonl", runNumber))
 		if _, err := os.Stat(runPath); err == nil {
 			return runPath
 		}
-	}
-
-	// Try generic post-completion file
-	path := filepath.Join(logDir, "post-completion-session-transcript.jsonl")
-	if _, err := os.Stat(path); err == nil {
-		return path
+	} else {
+		// Run 1 uses generic format
+		path := filepath.Join(logDir, "post-completion-session-transcript.jsonl")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
 	}
 
 	return ""
@@ -366,8 +369,11 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 	var title string
 
 	if isPostCompletion {
-		// For post-completion, default to latest run or 1
-		runNumber = s.getLatestPostCompletionRun(entry.LogDir)
+		// Use entry's run number for file naming (not filesystem scan)
+		runNumber = entry.RunNumber
+		if runNumber == 0 {
+			runNumber = 1 // Default for legacy entries without RunNumber
+		}
 		if runStr != "" {
 			var parseErr error
 			runNumber, parseErr = strconv.Atoi(runStr)
@@ -387,8 +393,12 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Default run number to latest for this phase
-		runNumber = s.getPhaseRunCount(entry, phase)
+		// Use entry's run number for file naming (not phase retry count)
+		// RunNumber determines file naming convention (1 = generic, 2+ = numbered)
+		runNumber = entry.RunNumber
+		if runNumber == 0 {
+			runNumber = 1 // Default for legacy entries without RunNumber
+		}
 		if runStr != "" {
 			runNumber, parseErr = strconv.Atoi(runStr)
 			if parseErr != nil || runNumber < 1 {
@@ -475,55 +485,23 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 	s.renderTemplate(w, "layout.html", "transcript.html", data)
 }
 
-// getPhaseRunCount returns the run count for a phase from the registry entry.
-// Defaults to 1 if the phase is not found.
-func (s *Server) getPhaseRunCount(entry *registry.RunEntry, phase int) int {
-	for _, p := range entry.Phases {
-		if p.Number == phase {
-			if p.RunCount > 0 {
-				return p.RunCount
-			}
-			return 1
-		}
-	}
-	return 1
-}
-
-// getLatestPostCompletionRun scans for the highest post-completion run number.
-// Returns 1 if no numbered runs are found.
-func (s *Server) getLatestPostCompletionRun(logDir string) int {
-	pattern := filepath.Join(logDir, "post-completion-run-*-session-transcript.jsonl")
-	matches, err := filepath.Glob(pattern)
-	if err != nil || len(matches) == 0 {
-		return 1
-	}
-
-	// Find highest run number
-	highest := 1
-	for _, match := range matches {
-		base := filepath.Base(match)
-		var runNum int
-		if _, err := fmt.Sscanf(base, "post-completion-run-%d-session-transcript.jsonl", &runNum); err == nil {
-			if runNum > highest {
-				highest = runNum
-			}
-		}
-	}
-	return highest
-}
-
-// findTranscriptFile finds the transcript file for a phase and run.
+// findTranscriptFile finds the transcript file for a phase based on run number.
+// File naming convention follows logs/manager.go:
+// - Run 1: phase-N-transcript.jsonl
+// - Run 2+: phase-N-run-M-transcript.jsonl
 func (s *Server) findTranscriptFile(logDir string, phase, runNumber int) string {
-	// Try run-specific file first
-	runPath := filepath.Join(logDir, fmt.Sprintf("phase-%d-run-%d-transcript.jsonl", phase, runNumber))
-	if _, err := os.Stat(runPath); err == nil {
-		return runPath
-	}
-
-	// Try generic phase file
-	phasePath := filepath.Join(logDir, fmt.Sprintf("phase-%d-transcript.jsonl", phase))
-	if _, err := os.Stat(phasePath); err == nil {
-		return phasePath
+	if runNumber > 1 {
+		// Run 2+ uses numbered format
+		runPath := filepath.Join(logDir, fmt.Sprintf("phase-%d-run-%d-transcript.jsonl", phase, runNumber))
+		if _, err := os.Stat(runPath); err == nil {
+			return runPath
+		}
+	} else {
+		// Run 1 uses generic format
+		phasePath := filepath.Join(logDir, fmt.Sprintf("phase-%d-transcript.jsonl", phase))
+		if _, err := os.Stat(phasePath); err == nil {
+			return phasePath
+		}
 	}
 
 	return ""


### PR DESCRIPTION
## Summary

- Fix relative path bug in registry entries that prevented web interface from locating log directories
- Fix incorrect file naming lookup that used retry count instead of orbit run number
- Add support for new Claude Code log format with queue-operation entries

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [x] Lint passes
- [x] Verified transcript parsing works with new log format