### PR TITLE
Fix T-702: IsPathWithinDir Rejects Valid In-Tree Paths Whose Relative Segment Starts With ".."

### DIFF
--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -121,6 +121,13 @@ func IsPathWithinDir(path, dir string) bool {
 		return false
 	}
 
-	// If relative path starts with "..", the file is outside the directory
-	return !strings.HasPrefix(rel, "..")
+	// The file is outside the directory only when the first path segment
+	// of rel is the literal parent-directory marker "..". Compare it as a
+	// discrete segment so legitimate names that merely begin with ".."
+	// (e.g. "..cache/file.txt", "..session.jsonl") are still treated as
+	// in-tree.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
 }

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -223,6 +223,23 @@ func TestIsPathWithinDir(t *testing.T) {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
+	// Regression for T-702: directories and files whose names start with ".."
+	// (but are not the parent-directory segment "..") are valid in-tree paths and
+	// must not be rejected. Previously HasPrefix(rel, "..") incorrectly rejected
+	// these, e.g. "..cache/file.txt" or "..session.jsonl".
+	dotDotDir := filepath.Join(tmpDir, "..cache")
+	if err := os.MkdirAll(dotDotDir, 0755); err != nil {
+		t.Fatalf("failed to create ..cache dir: %v", err)
+	}
+	dotDotFileInDir := filepath.Join(dotDotDir, "file.txt")
+	if err := os.WriteFile(dotDotFileInDir, []byte("ok"), 0644); err != nil {
+		t.Fatalf("failed to create ..cache/file.txt: %v", err)
+	}
+	dotDotSibling := filepath.Join(tmpDir, "..session.jsonl")
+	if err := os.WriteFile(dotDotSibling, []byte("ok"), 0644); err != nil {
+		t.Fatalf("failed to create ..session.jsonl: %v", err)
+	}
+
 	tests := []struct {
 		name     string
 		path     string
@@ -258,6 +275,20 @@ func TestIsPathWithinDir(t *testing.T) {
 			path:     filepath.Join(subDir, "nonexistent.txt"),
 			dir:      subDir,
 			expected: false, // File doesn't exist, so EvalSymlinks fails
+		},
+		{
+			// T-702 regression: child directory whose name starts with ".."
+			name:     "child dir name starts with double dot",
+			path:     dotDotFileInDir,
+			dir:      tmpDir,
+			expected: true,
+		},
+		{
+			// T-702 regression: sibling file whose name starts with ".."
+			name:     "file name starts with double dot",
+			path:     dotDotSibling,
+			dir:      tmpDir,
+			expected: true,
 		},
 	}
 

--- a/specs/bugfixes/ispathwithindir-relative-double-dot/report.md
+++ b/specs/bugfixes/ispathwithindir-relative-double-dot/report.md
@@ -1,0 +1,127 @@
+# Bugfix Report: IsPathWithinDir Rejects Valid In-Tree Paths Whose Relative Segment Starts With ".."
+
+**Date:** 2026-04-28
+**Status:** Fixed
+**Transit:** T-702
+
+## Description of the Issue
+
+`internal/web/middleware.go:IsPathWithinDir` decides whether `path` lives under `dir`
+by computing `filepath.Rel(resolvedDir, resolved)` and then checking
+`!strings.HasPrefix(rel, "..")`. That prefix check treats any relative path
+starting with the two-character sequence `".."` as outside the directory,
+including legitimate child paths whose first segment merely begins with `".."`,
+for example `..cache/file.txt` or `..session.jsonl`.
+
+**Reproduction steps:**
+1. Create a directory `tmp/`.
+2. Inside it, create `tmp/..cache/file.txt` (a normal file in a normally named child directory).
+3. Call `IsPathWithinDir("tmp/..cache/file.txt", "tmp")`.
+4. Observe that it returns `false` even though the file lives under `tmp`.
+
+**Impact:** Severity moderate. Callers in `internal/web/handlers.go` (transcript serving)
+and `internal/sessions/resolver.go` (session resolution across all agents) treat the
+`false` return as "outside allowed dir" and surface `not found` for legitimate files.
+The bug manifests for any user whose project tree contains a directory or file whose
+name begins with two dots — uncommon but legal on every supported OS.
+
+## Investigation Summary
+
+- **Symptoms examined:** Ticket reports false negatives on names beginning with `..`.
+- **Code inspected:** `internal/web/middleware.go` (`IsPathWithinDir`),
+  `internal/web/middleware_test.go` (existing coverage),
+  callers in `internal/web/handlers.go` and `internal/sessions/resolver.go`.
+- **Hypotheses tested:**
+  - The symlink resolution path was not at fault — it correctly resolves both ends.
+  - `filepath.Rel` returns the literal path — `..cache/file.txt` is preserved verbatim.
+  - The defect lives in the final classification step: `strings.HasPrefix(rel, "..")`
+    matches both the parent-directory segment `".."` and any longer name beginning
+    with two dots.
+
+## Discovered Root Cause
+
+**Defect type:** Logic error — improper substring/prefix check used as a path-segment check.
+
+`filepath.Rel` produces a relative path whose first segment is `".."` only when the
+target sits outside `dir`. To detect that, the first path segment must be compared
+exactly. Using `strings.HasPrefix(rel, "..")` instead checks for any string that
+begins with `..` — including names like `..cache` or `..session.jsonl` — which are
+valid in-tree filenames.
+
+**Why it occurred:** The author conflated "first segment equals `..`" with "starts with `..`".
+Both happen to be true for traversal cases, but the prefix form also matches valid names.
+
+**Contributing factors:**
+- Tests exercised only the basic in/out cases; no test used a name starting with `..`,
+  so the bug never surfaced.
+- The check is used by safety-critical callers (path validation), so the conservative
+  failure mode (reject) hid the bug as a "file not found" rather than a security or
+  panic-style symptom.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/web/middleware.go:106` — Replace `!strings.HasPrefix(rel, "..")` with an
+  explicit check that rejects only when `rel == ".."` or `rel` starts with
+  `".." + string(filepath.Separator)`. This matches the parent-directory segment as
+  a discrete path component instead of as a prefix.
+
+**Approach rationale:** The fix is a minimal, local change to the same classification
+line. It uses `filepath.Separator` so it stays correct on Windows (`\`) and Unix (`/`).
+It preserves the existing symlink-resolution safeguards (everything before the final
+return is unchanged) and remains O(1).
+
+**Alternatives considered:**
+- Splitting `rel` with `filepath.SplitList` or `strings.Split` and inspecting the
+  first segment — Rejected. More allocations and code for no extra correctness;
+  `filepath.Rel`'s contract guarantees the leading-`..` form for outside paths.
+- Using `filepath.IsLocal(rel)` (Go 1.20+) — Rejected. `IsLocal` also rejects
+  absolute paths and paths containing reserved Windows names, which would change
+  behaviour beyond the scope of this bugfix and could surprise existing callers.
+
+## Regression Test
+
+**Test file:** `internal/web/middleware_test.go`
+**Test cases added to `TestIsPathWithinDir`:**
+- `child dir name starts with double dot` — `tmp/..cache/file.txt` inside `tmp` must return `true`.
+- `file name starts with double dot` — `tmp/..session.jsonl` inside `tmp` must return `true`.
+
+**What they verify:** Names whose first character pair is `".."` but which are not
+the parent-directory segment are correctly classified as in-tree.
+
+**Run command:** `go test ./internal/web/ -run TestIsPathWithinDir -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/web/middleware.go` | Tighten the leading-`..` check in `IsPathWithinDir` so only the literal `..` segment counts as outside the directory. |
+| `internal/web/middleware_test.go` | Add two regression cases covering names that begin with `..`. |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Existing `path traversal attempt` and symlink-escape tests still pass, confirming
+  that genuine traversal and symlink-escape cases remain rejected.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When checking for a leading path segment, compare the first segment explicitly or
+  match `segment` followed by `filepath.Separator` — never use `strings.HasPrefix`
+  alone for path-segment classification.
+- When introducing a path-validation primitive, include a test case for a filename
+  whose first characters coincide with the special segment being detected (e.g. a
+  file named `..foo` when the check is for the `..` segment).
+
+## Related
+
+- Transit ticket: T-702
+- Caller sites for `IsPathWithinDir`:
+  - `internal/web/handlers.go:483`
+  - `internal/sessions/resolver.go` (multiple call sites)


### PR DESCRIPTION
## Summary

Fixes T-702. `internal/web/middleware.go:IsPathWithinDir` previously used `strings.HasPrefix(rel, \"..\")` to decide whether a path lived under the allowed directory. That also matched legitimate child names whose first characters happen to be `..` (e.g. `..cache/file.txt`, `..session.jsonl`), so transcript serving and session resolution returned `not found` for real files.

## Root Cause

`filepath.Rel` returns a relative path whose first segment is exactly `..` only when the target is outside `dir`. `strings.HasPrefix` doesn't enforce a segment boundary, so any name beginning with two dots was misclassified as outside.

## Fix

Reject only when `rel == \"..\"` or `rel` starts with `\"..\" + string(filepath.Separator)`. Everything before the final classification (symlink resolution, `filepath.Rel`) is unchanged, and traversal/symlink-escape behaviour is preserved.

See `specs/bugfixes/ispathwithindir-relative-double-dot/report.md` for the investigation, root cause analysis, and verification details.

## Test plan

- [x] New regression cases in `TestIsPathWithinDir` cover `..cache/file.txt` and `..session.jsonl`
- [x] Existing `path traversal attempt` and `TestIsPathWithinDirSymlinks` still pass
- [x] `make test` passes
- [x] `make lint` passes