### PR TITLE
Fix T-678: Honor configured agent timeout during comparison

### DIFF
--- a/cmd/orbit/compare.go
+++ b/cmd/orbit/compare.go
@@ -156,6 +156,10 @@ func compareCommand(args []string) error {
 		agentCfg := agents.AgentConfig{
 			AutoApprove: true, // Comparison runs non-interactively
 		}
+		// appConfig is always non-nil in this branch (loaded above when fromFile
+		// is empty). The nil check is defensive in case the loading logic above
+		// changes; remove it together with the surrounding guard if appConfig
+		// is hoisted out of the conditional.
 		if appConfig != nil {
 			if cfg := appConfig.GetAgentConfig("claude-code"); cfg.Timeout > 0 {
 				agentCfg.Timeout = cfg.Timeout

--- a/cmd/orbit/compare.go
+++ b/cmd/orbit/compare.go
@@ -47,9 +47,11 @@ func compareCommand(args []string) error {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	// Config only needed for AI agent invocation, not for loading saved results
+	// Config only needed for AI agent invocation, not for loading saved results.
+	// Captured at function scope so it can supply AgentConfig.Timeout below (T-678).
+	var appConfig *config.Config
 	if *fromFile == "" {
-		appConfig := config.Load(workDir)
+		appConfig = config.Load(workDir)
 		if err := appConfig.RequireConfigFile(); err != nil {
 			return err
 		}
@@ -146,21 +148,35 @@ func compareCommand(args []string) error {
 		// Read spec context for additional context
 		specContext := readSpecContext(specDir)
 
-		// Run comparison with a timeout to prevent indefinite hangs
+		// Run comparison with a timeout to prevent indefinite hangs.
+		// Honor AgentConfig.Timeout when set (T-678); fall back to the hardcoded
+		// default to preserve the original safety net for users on default config.
 		fmt.Println("\nRunning comparison analysis...")
 
-		comparisonCtx, cancel := context.WithTimeout(ctx, comparison.DefaultTimeout)
+		agentCfg := agents.AgentConfig{
+			AutoApprove: true, // Comparison runs non-interactively
+		}
+		if appConfig != nil {
+			if cfg := appConfig.GetAgentConfig("claude-code"); cfg.Timeout > 0 {
+				agentCfg.Timeout = cfg.Timeout
+			}
+		}
+
+		comparisonTimeout := agentCfg.Timeout
+		if comparisonTimeout <= 0 {
+			comparisonTimeout = comparison.DefaultTimeout
+		}
+		comparisonCtx, cancel := context.WithTimeout(ctx, comparisonTimeout)
 		defer cancel()
 
 		// Get the default agent (claude-code) with AutoApprove for non-interactive use
-		agent, err := agents.Get("claude-code", agents.AgentConfig{
-			AutoApprove: true, // Comparison runs non-interactively
-		})
+		agent, err := agents.Get("claude-code", agentCfg)
 		if err != nil {
 			return fmt.Errorf("failed to get agent: %w", err)
 		}
 
-		adapter := comparison.NewAgentAdapter(agent, workDir)
+		adapter := comparison.NewAgentAdapter(agent, workDir).
+			WithTimeout(comparisonTimeout)
 		comparator := comparison.NewComparator(adapter, *compareCmd)
 
 		// Use the unified comparison method with summaries only (diffs excluded to save context)

--- a/docs/agent-notes/comparison-execution.md
+++ b/docs/agent-notes/comparison-execution.md
@@ -17,9 +17,9 @@ Comparison prompts include all data inline (diffs, stats, changelogs, spec conte
 - File reading (unnecessary, data is inline)
 - Command execution (running tests/lint is not the comparison's job)
 
-### Timeout on comparison context (2026-02-10, updated 2026-02-17)
+### Timeout on comparison context (2026-02-10, updated 2026-04-28 for T-678)
 
-A 30-minute timeout (`comparison.DefaultTimeout`) is applied to prevent indefinite hangs from API stalls. The timeout is applied via `context.WithTimeout()` and passed to `CompareUnified()`, which threads it through to `RunCustomPrompt()` per-call. The adapter no longer stores context — it receives it as a method parameter, following Go best practices.
+When `AgentConfig.Timeout` is set (via `.orbit.yaml` `agents.<agent>.timeout`), it is honored for the comparison run too — both via the wrapping `context.WithTimeout()` and via `RunOptions.Timeout` (set on the adapter through `AgentAdapter.WithTimeout`). When no timeout is configured, the hardcoded 30-minute `comparison.DefaultTimeout` is still applied as a safety net to prevent indefinite hangs from API stalls. The adapter no longer stores context — it receives it as a method parameter, following Go best practices. Both call sites (`internal/orbit/comparison.go` and `cmd/orbit/compare.go`) read the timeout the same way so behaviour stays consistent.
 
 ### Agent writes comparison JSON to file (2026-02-10)
 

--- a/internal/comparison/adapter.go
+++ b/internal/comparison/adapter.go
@@ -2,6 +2,7 @@ package comparison
 
 import (
 	"context"
+	"time"
 
 	"github.com/arjenschwarz/orbit/internal/agents"
 )
@@ -12,6 +13,7 @@ type AgentAdapter struct {
 	agent     agents.Agent
 	workDir   string
 	extraArgs []string
+	timeout   time.Duration
 }
 
 // NewAgentAdapter creates a new adapter wrapping the given agent.
@@ -38,12 +40,23 @@ func (a *AgentAdapter) WithExtraArgs(args ...string) *AgentAdapter {
 	return &cp
 }
 
+// WithTimeout returns a copy of the adapter with a per-execution timeout.
+// The timeout is forwarded to RunOptions.Timeout so the underlying agent's
+// executor enforces it (mirroring how phase execution honors
+// AgentConfig.Timeout). A zero duration means no per-execution timeout.
+func (a *AgentAdapter) WithTimeout(timeout time.Duration) *AgentAdapter {
+	cp := *a
+	cp.timeout = timeout
+	return &cp
+}
+
 // RunCustomPrompt implements the promptRunner interface by delegating to agent.Run().
 func (a *AgentAdapter) RunCustomPrompt(ctx context.Context, prompt string) (*agents.RunResult, error) {
 	opts := agents.RunOptions{
 		Prompt:    prompt,
 		WorkDir:   a.workDir,
 		ExtraArgs: a.extraArgs,
+		Timeout:   a.timeout,
 	}
 	return a.agent.Run(ctx, opts)
 }

--- a/internal/comparison/adapter_test.go
+++ b/internal/comparison/adapter_test.go
@@ -3,6 +3,7 @@ package comparison
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/arjenschwarz/orbit/internal/agents"
 	"github.com/arjenschwarz/orbit/internal/testutil"
@@ -168,6 +169,77 @@ func TestAgentAdapter_WithExtraArgs(t *testing.T) {
 	calls := agent.Recorder().Calls()
 	require.Len(t, calls, 1)
 	assert.Equal(t, []string{"--tools", ""}, calls[0].Options.ExtraArgs)
+}
+
+func TestAgentAdapter_WithTimeout_PassesTimeoutToRunOptions(t *testing.T) {
+	// Regression test for T-678: AgentAdapter must propagate the configured
+	// agent timeout into RunOptions.Timeout so the comparison run honors
+	// AgentConfig.Timeout instead of relying on a hardcoded 30-minute ceiling.
+	scenario := testutil.NewScenario().
+		Success("session-1", 0.01).
+		Build()
+
+	agent := testutil.NewTestAgent(t, "mock", scenario)
+	t.Cleanup(func() { agent.AssertAllConsumed(t) })
+
+	timeout := 90 * time.Minute
+	adapter := NewAgentAdapter(agent, "/tmp/test").WithTimeout(timeout)
+
+	_, err := adapter.RunCustomPrompt(context.Background(), "test prompt")
+	require.NoError(t, err)
+
+	calls := agent.Recorder().Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, timeout, calls[0].Options.Timeout)
+}
+
+func TestAgentAdapter_WithTimeout_DoesNotMutateOriginal(t *testing.T) {
+	// Regression test for T-678: WithTimeout returns a copy, mirroring the
+	// behaviour of WithExtraArgs to keep the API consistent.
+	scenario := testutil.NewScenario().
+		Success("session-1", 0.01).
+		Success("session-2", 0.01).
+		Build()
+
+	agent := testutil.NewTestAgent(t, "mock", scenario)
+	t.Cleanup(func() { agent.AssertAllConsumed(t) })
+
+	original := NewAgentAdapter(agent, "/tmp/test")
+	withTimeout := original.WithTimeout(45 * time.Minute)
+
+	_, err := original.RunCustomPrompt(context.Background(), "prompt1")
+	require.NoError(t, err)
+
+	calls := agent.Recorder().Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, time.Duration(0), calls[0].Options.Timeout)
+
+	_, err = withTimeout.RunCustomPrompt(context.Background(), "prompt2")
+	require.NoError(t, err)
+
+	calls = agent.Recorder().Calls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, 45*time.Minute, calls[1].Options.Timeout)
+}
+
+func TestAgentAdapter_RunCustomPrompt_DefaultsToZeroTimeout(t *testing.T) {
+	// When no timeout is configured the adapter must leave RunOptions.Timeout
+	// at zero so agents inherit the parent context deadline only.
+	scenario := testutil.NewScenario().
+		Success("session-1", 0.01).
+		Build()
+
+	agent := testutil.NewTestAgent(t, "mock", scenario)
+	t.Cleanup(func() { agent.AssertAllConsumed(t) })
+
+	adapter := NewAgentAdapter(agent, "/tmp/test")
+
+	_, err := adapter.RunCustomPrompt(context.Background(), "test prompt")
+	require.NoError(t, err)
+
+	calls := agent.Recorder().Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, time.Duration(0), calls[0].Options.Timeout)
 }
 
 func TestAgentAdapter_WithExtraArgs_DoesNotMutateOriginal(t *testing.T) {

--- a/internal/orbit/comparison.go
+++ b/internal/orbit/comparison.go
@@ -46,10 +46,17 @@ func (o *Orbit) runComparison(ctx context.Context) error {
 	specContext := o.readSpecContext()
 
 	// Create comparator with timeout to prevent indefinite hangs from stalled API connections.
-	comparisonCtx, cancel := context.WithTimeout(o.shutdownCtx, comparison.DefaultTimeout)
+	// Honor AgentConfig.Timeout when set (T-678); fall back to the hardcoded default
+	// to preserve the original safety net for users on default configuration.
+	comparisonTimeout := o.config.AgentConfig.Timeout
+	if comparisonTimeout <= 0 {
+		comparisonTimeout = comparison.DefaultTimeout
+	}
+	comparisonCtx, cancel := context.WithTimeout(o.shutdownCtx, comparisonTimeout)
 	defer cancel()
 
-	adapter := comparison.NewAgentAdapter(o.agent, o.config.WorkingDir)
+	adapter := comparison.NewAgentAdapter(o.agent, o.config.WorkingDir).
+		WithTimeout(comparisonTimeout)
 	comparator := comparison.NewComparator(adapter, o.config.CompareCommand)
 
 	comparisonJSONPath := filepath.Join(o.config.SpecDir, ".orbit", "comparison.json")


### PR DESCRIPTION
## Summary

- Comparison runs (`orbit run --variants` and `orbit compare`) ignored the configured `AgentConfig.Timeout`. The agent invocation was wrapped in a hardcoded 30-minute context and `comparison.AgentAdapter` never set `RunOptions.Timeout`, so the per-agent timeout from `.orbit.yaml` had no effect on the comparison phase.
- This is the comparison-side analogue of T-584, which fixed the same plumbing for phase, pre-prompt, and post-prompt execution.

## Changes

- `internal/comparison/adapter.go`: add `WithTimeout(time.Duration)` builder and propagate the value into `RunOptions.Timeout`. Mirrors the `WithExtraArgs` builder style.
- `internal/orbit/comparison.go`: use `AgentConfig.Timeout` for both the wrapping `context.WithTimeout` and the adapter, falling back to `comparison.DefaultTimeout` only when no timeout is configured.
- `cmd/orbit/compare.go`: same wiring for the standalone subcommand. Reads the timeout via `appConfig.GetAgentConfig("claude-code")`.
- `internal/comparison/adapter_test.go`: regression tests covering `WithTimeout` propagation, copy-on-write semantics, and the zero-timeout default.
- `docs/agent-notes/comparison-execution.md`: updated to describe the new behaviour.

## Behaviour

- With `agents.<agent>.timeout` set in `.orbit.yaml`, the comparison context and the executor-level per-execution timeout both use that duration.
- With no timeout configured, the existing 30-minute ceiling still applies as a safety net.

## Test plan

- [x] `go test ./internal/comparison/ -run TestAgentAdapter`
- [x] `make test`
- [x] `make lint`