### PR TITLE
Fix T-679: Bound Auto-Consolidation Agent Runs With Timeout

### DIFF
--- a/internal/consolidation/consolidator.go
+++ b/internal/consolidation/consolidator.go
@@ -488,9 +488,8 @@ func (c *Consolidator) Run(ctx context.Context) (*ConsolidationResult, error) {
 	return consolidationResult, nil
 }
 
-// agentTimeout returns the per-invocation timeout for agent calls. A zero
-// Config.Timeout falls back to DefaultTimeout so callers always get a bound
-// even when the field is left unset. Regression: T-679.
+// agentTimeout returns the per-invocation timeout for agent calls, falling
+// back to DefaultTimeout when Config.Timeout is unset.
 func (c *Consolidator) agentTimeout() time.Duration {
 	if c.config.Timeout > 0 {
 		return c.config.Timeout
@@ -502,7 +501,7 @@ func (c *Consolidator) agentTimeout() time.Duration {
 // Uses the shared retry executor with proper error classification via the
 // agent's registered classifier (instead of type-asserting the agent).
 // Each agent invocation is bounded by agentTimeout() so a hung session
-// cannot run indefinitely (T-679).
+// cannot run indefinitely.
 // Implements: [5.8], [5.9]
 func (c *Consolidator) runWithRetry(ctx context.Context, prompt string) (*agents.RunResult, error) {
 	const maxRetries = 5
@@ -682,7 +681,7 @@ func (c *Consolidator) runTests(ctx context.Context) (bool, error) {
 
 // runPostPrompt executes the configured post-prompt through the agent.
 // The agent invocation is bounded by agentTimeout() so a hung post-prompt
-// session cannot run indefinitely (T-679).
+// session cannot run indefinitely.
 func (c *Consolidator) runPostPrompt(ctx context.Context) (bool, error) {
 	if c.config.PostPrompt == "" {
 		return true, nil

--- a/internal/consolidation/consolidator.go
+++ b/internal/consolidation/consolidator.go
@@ -488,9 +488,21 @@ func (c *Consolidator) Run(ctx context.Context) (*ConsolidationResult, error) {
 	return consolidationResult, nil
 }
 
+// agentTimeout returns the per-invocation timeout for agent calls. A zero
+// Config.Timeout falls back to DefaultTimeout so callers always get a bound
+// even when the field is left unset. Regression: T-679.
+func (c *Consolidator) agentTimeout() time.Duration {
+	if c.config.Timeout > 0 {
+		return c.config.Timeout
+	}
+	return DefaultTimeout
+}
+
 // runWithRetry runs the agent with exponential backoff for retryable errors.
 // Uses the shared retry executor with proper error classification via the
 // agent's registered classifier (instead of type-asserting the agent).
+// Each agent invocation is bounded by agentTimeout() so a hung session
+// cannot run indefinitely (T-679).
 // Implements: [5.8], [5.9]
 func (c *Consolidator) runWithRetry(ctx context.Context, prompt string) (*agents.RunResult, error) {
 	const maxRetries = 5
@@ -501,12 +513,14 @@ func (c *Consolidator) runWithRetry(ctx context.Context, prompt string) (*agents
 		MaxRetries: maxRetries,
 		Sleep:      time.Sleep,
 		Execute: func(ctx context.Context, _ int) (*agents.RunResult, error) {
+			runCtx, cancel := context.WithTimeout(ctx, c.agentTimeout())
+			defer cancel()
 			opts := agents.RunOptions{
 				Prompt:    prompt,
 				SessionID: sessionID,
 				WorkDir:   worktreePath,
 			}
-			return c.config.Agent.Run(ctx, opts)
+			return c.config.Agent.Run(runCtx, opts)
 		},
 		Classify: func(result *agents.RunResult, err error) *agents.ClassifiedError {
 			// Success: no error and agent did not report an error condition.
@@ -667,6 +681,8 @@ func (c *Consolidator) runTests(ctx context.Context) (bool, error) {
 }
 
 // runPostPrompt executes the configured post-prompt through the agent.
+// The agent invocation is bounded by agentTimeout() so a hung post-prompt
+// session cannot run indefinitely (T-679).
 func (c *Consolidator) runPostPrompt(ctx context.Context) (bool, error) {
 	if c.config.PostPrompt == "" {
 		return true, nil
@@ -674,13 +690,16 @@ func (c *Consolidator) runPostPrompt(ctx context.Context) (bool, error) {
 
 	worktreePath := c.recovery.worktreePath
 
+	runCtx, cancel := context.WithTimeout(ctx, c.agentTimeout())
+	defer cancel()
+
 	opts := agents.RunOptions{
 		Prompt:    c.config.PostPrompt,
 		SessionID: uuid.NewString(),
 		WorkDir:   worktreePath,
 	}
 
-	result, err := c.config.Agent.Run(ctx, opts)
+	result, err := c.config.Agent.Run(runCtx, opts)
 	if err != nil {
 		return false, fmt.Errorf("post-prompt failed: %w", err)
 	}

--- a/internal/consolidation/consolidator_test.go
+++ b/internal/consolidation/consolidator_test.go
@@ -903,6 +903,193 @@ func TestRecoveryPartialFailure(t *testing.T) {
 	})
 }
 
+// deadlineCapturingAgent records the deadline of every Run/Resume context for
+// inspection. Used by T-679 regression tests to verify the consolidator wraps
+// agent invocations with a deadline so they can't hang indefinitely.
+type deadlineCapturingAgent struct {
+	name        string
+	result      *agents.RunResult
+	deadlines   []time.Time
+	hasDeadline []bool
+}
+
+func (a *deadlineCapturingAgent) Name() string              { return a.name }
+func (a *deadlineCapturingAgent) CLICommand() string        { return "mock" }
+func (a *deadlineCapturingAgent) IsInstalled() bool         { return true }
+func (a *deadlineCapturingAgent) Version() (string, error)  { return "1.0.0", nil }
+func (a *deadlineCapturingAgent) DefaultSessionDir() string { return "/tmp" }
+func (a *deadlineCapturingAgent) DiscoverSessions(_ context.Context, _ string) ([]agents.SessionInfo, error) {
+	return nil, nil
+}
+func (a *deadlineCapturingAgent) Run(ctx context.Context, _ agents.RunOptions) (*agents.RunResult, error) {
+	dl, ok := ctx.Deadline()
+	a.deadlines = append(a.deadlines, dl)
+	a.hasDeadline = append(a.hasDeadline, ok)
+	return a.result, nil
+}
+func (a *deadlineCapturingAgent) Resume(ctx context.Context, _ string, opts agents.RunOptions) (*agents.RunResult, error) {
+	return a.Run(ctx, opts)
+}
+
+// hangingAgent blocks until its context is canceled. Used to verify the
+// consolidator's per-invocation timeout actually terminates a stuck agent.
+type hangingAgent struct {
+	name string
+}
+
+func (a *hangingAgent) Name() string              { return a.name }
+func (a *hangingAgent) CLICommand() string        { return "mock" }
+func (a *hangingAgent) IsInstalled() bool         { return true }
+func (a *hangingAgent) Version() (string, error)  { return "1.0.0", nil }
+func (a *hangingAgent) DefaultSessionDir() string { return "/tmp" }
+func (a *hangingAgent) DiscoverSessions(_ context.Context, _ string) ([]agents.SessionInfo, error) {
+	return nil, nil
+}
+func (a *hangingAgent) Run(ctx context.Context, _ agents.RunOptions) (*agents.RunResult, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+func (a *hangingAgent) Resume(ctx context.Context, _ string, opts agents.RunOptions) (*agents.RunResult, error) {
+	return a.Run(ctx, opts)
+}
+
+// TestRunWithRetry_AppliesTimeout verifies that runWithRetry bounds each agent
+// invocation with a deadline so a hung session can't run forever.
+// Regression test for T-679: consolidation paths previously called the agent
+// without setting RunOptions.Timeout and without an explicit
+// comparison-style deadline.
+func TestRunWithRetry_AppliesTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agent context has a deadline", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		agent := &deadlineCapturingAgent{
+			name: "test-agent",
+			result: &agents.RunResult{
+				SessionID: "test-session",
+				ExitCode:  0,
+				Output:    "ok",
+			},
+		}
+
+		mgr := createTestManagerWithVariants(t, 2, tmpDir)
+		cfg := Config{
+			SpecName:  "test-spec",
+			SpecDir:   tmpDir,
+			VariantID: 1,
+			Agent:     agent,
+		}
+
+		consolidator, err := NewConsolidator(cfg, mgr)
+		require.NoError(t, err)
+
+		_, err = consolidator.runWithRetry(context.Background(), "test prompt")
+		require.NoError(t, err)
+		require.Len(t, agent.hasDeadline, 1, "agent should have been called once")
+		assert.True(t, agent.hasDeadline[0], "context passed to agent must have a deadline")
+	})
+
+	t.Run("hung agent is terminated by timeout", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		agent := &hangingAgent{name: "test-agent"}
+
+		mgr := createTestManagerWithVariants(t, 2, tmpDir)
+		cfg := Config{
+			SpecName:  "test-spec",
+			SpecDir:   tmpDir,
+			VariantID: 1,
+			Agent:     agent,
+			Timeout:   50 * time.Millisecond, // short timeout for test speed
+		}
+
+		consolidator, err := NewConsolidator(cfg, mgr)
+		require.NoError(t, err)
+
+		start := time.Now()
+		// Use a generous parent deadline so the test fails clearly if the
+		// per-invocation timeout doesn't fire.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err = consolidator.runWithRetry(ctx, "test prompt")
+		elapsed := time.Since(start)
+
+		require.Error(t, err, "runWithRetry must return an error when agent hangs")
+		assert.Less(t, elapsed, 4*time.Second, "runWithRetry should terminate within timeout, not run until parent cancels")
+	})
+}
+
+// TestRunPostPrompt_AppliesTimeout verifies that runPostPrompt bounds the agent
+// invocation with a deadline so a hung session can't run forever.
+// Regression test for T-679.
+func TestRunPostPrompt_AppliesTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agent context has a deadline", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		agent := &deadlineCapturingAgent{
+			name: "test-agent",
+			result: &agents.RunResult{
+				SessionID: "test-session",
+				ExitCode:  0,
+				Output:    "ok",
+			},
+		}
+
+		mgr := createTestManagerWithVariants(t, 2, tmpDir)
+		cfg := Config{
+			SpecName:   "test-spec",
+			SpecDir:    tmpDir,
+			VariantID:  1,
+			Agent:      agent,
+			PostPrompt: "review the work",
+		}
+
+		consolidator, err := NewConsolidator(cfg, mgr)
+		require.NoError(t, err)
+
+		ok, err := consolidator.runPostPrompt(context.Background())
+		require.NoError(t, err)
+		assert.True(t, ok)
+		require.Len(t, agent.hasDeadline, 1, "agent should have been called once")
+		assert.True(t, agent.hasDeadline[0], "context passed to agent must have a deadline")
+	})
+
+	t.Run("hung agent is terminated by timeout", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		agent := &hangingAgent{name: "test-agent"}
+
+		mgr := createTestManagerWithVariants(t, 2, tmpDir)
+		cfg := Config{
+			SpecName:   "test-spec",
+			SpecDir:    tmpDir,
+			VariantID:  1,
+			Agent:      agent,
+			PostPrompt: "review the work",
+			Timeout:    50 * time.Millisecond,
+		}
+
+		consolidator, err := NewConsolidator(cfg, mgr)
+		require.NoError(t, err)
+
+		start := time.Now()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err = consolidator.runPostPrompt(ctx)
+		elapsed := time.Since(start)
+
+		require.Error(t, err, "runPostPrompt must return an error when agent hangs")
+		assert.Less(t, elapsed, 4*time.Second, "runPostPrompt should terminate within timeout, not run until parent cancels")
+	})
+}
+
 // TestRunWithRetry_IsErrorTreatedAsFailure verifies that runWithRetry treats
 // agent-level IsError=true as a failure even when err==nil and result.Error==nil.
 // Regression test for T-609.

--- a/internal/consolidation/consolidator_test.go
+++ b/internal/consolidation/consolidator_test.go
@@ -903,13 +903,12 @@ func TestRecoveryPartialFailure(t *testing.T) {
 	})
 }
 
-// deadlineCapturingAgent records the deadline of every Run/Resume context for
-// inspection. Used by T-679 regression tests to verify the consolidator wraps
+// deadlineCapturingAgent records whether every Run/Resume context carries a
+// deadline. Used by T-679 regression tests to verify the consolidator wraps
 // agent invocations with a deadline so they can't hang indefinitely.
 type deadlineCapturingAgent struct {
 	name        string
 	result      *agents.RunResult
-	deadlines   []time.Time
 	hasDeadline []bool
 }
 
@@ -922,8 +921,7 @@ func (a *deadlineCapturingAgent) DiscoverSessions(_ context.Context, _ string) (
 	return nil, nil
 }
 func (a *deadlineCapturingAgent) Run(ctx context.Context, _ agents.RunOptions) (*agents.RunResult, error) {
-	dl, ok := ctx.Deadline()
-	a.deadlines = append(a.deadlines, dl)
+	_, ok := ctx.Deadline()
 	a.hasDeadline = append(a.hasDeadline, ok)
 	return a.result, nil
 }

--- a/internal/consolidation/types.go
+++ b/internal/consolidation/types.go
@@ -11,7 +11,7 @@ import (
 // DefaultTimeout is the maximum duration for a single consolidation agent
 // invocation. This bounds both the consolidation prompt (runWithRetry) and the
 // post-prompt (runPostPrompt) so a stalled API connection or hung session can
-// never run indefinitely. Mirrors comparison.DefaultTimeout (T-679).
+// never run indefinitely.
 const DefaultTimeout = 30 * time.Minute
 
 // Config holds consolidation configuration.

--- a/internal/consolidation/types.go
+++ b/internal/consolidation/types.go
@@ -3,8 +3,16 @@
 package consolidation
 
 import (
+	"time"
+
 	"github.com/arjenschwarz/orbit/internal/agents"
 )
+
+// DefaultTimeout is the maximum duration for a single consolidation agent
+// invocation. This bounds both the consolidation prompt (runWithRetry) and the
+// post-prompt (runPostPrompt) so a stalled API connection or hung session can
+// never run indefinitely. Mirrors comparison.DefaultTimeout (T-679).
+const DefaultTimeout = 30 * time.Minute
 
 // Config holds consolidation configuration.
 type Config struct {
@@ -13,8 +21,9 @@ type Config struct {
 	VariantID    int
 	Agent        agents.Agent
 	AllowDirty   bool
-	PostPrompt   string // AI prompt after consolidation (renamed from PostCommand)
-	CustomPrompt string // User-provided instructions via --prompt
+	PostPrompt   string        // AI prompt after consolidation (renamed from PostCommand)
+	CustomPrompt string        // User-provided instructions via --prompt
+	Timeout      time.Duration // Per-invocation agent timeout (0 = DefaultTimeout)
 }
 
 // ConsolidationResult contains the outcome of a consolidation run.


### PR DESCRIPTION
## Summary

- Consolidation agent invocations were unbounded. `Consolidator.runWithRetry` and `Consolidator.runPostPrompt` built `agents.RunOptions` without `Timeout`, and `Consolidator.Run` had no comparison-style deadline either, so a stalled API connection or hung agent could run indefinitely during auto-consolidation.
- Added `consolidation.DefaultTimeout = 30 * time.Minute` (mirroring `comparison.DefaultTimeout`) and a `Config.Timeout` override.
- Wrapped each agent invocation in `context.WithTimeout` so per-attempt deadlines apply cleanly inside the existing retry/backoff loop.

## Root cause

The comparison path was retrofitted with `comparison.DefaultTimeout` after early production hangs (see `docs/agent-notes/comparison-execution.md`). The same safeguard never landed for the consolidation path that came later, even though it makes the same kind of long-running agent call. The two functions named in the ticket — `Consolidator.runWithRetry` and `Consolidator.runPostPrompt` — relied solely on the parent context having a deadline, but no caller wrapped the consolidator's context with one (`cmd/orbit/consolidate.go` uses a bare `context.Background()`, and `internal/orbit/comparison.go` only times out the comparison itself, not the follow-up consolidation).

## Test plan

- [x] `go test ./internal/consolidation/ -run "TestRunWithRetry_AppliesTimeout|TestRunPostPrompt_AppliesTimeout"` (new regression tests, both pass)
- [x] `make test`
- [x] `make lint`

## Notes

Per-attempt timeout (rather than wrapping the whole `RunWithRetry` loop) keeps retry backoff working: each attempt gets a fresh deadline. The choice to use `context.WithTimeout` instead of just populating `RunOptions.Timeout` is defense-in-depth — the timeout fires regardless of whether a future agent forwards the field.