### PR TITLE
Fix T-654: Environment Numeric Parsing Accepts Invalid Trailing Characters

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -409,11 +410,12 @@ func Load(workingDir string) *Config {
 }
 
 // parsePort attempts to parse a string as a valid port number.
+// The entire string must be a base-10 integer; leading/trailing whitespace,
+// sign prefixes, or any non-digit suffix are rejected (see T-654).
 func parsePort(s string) (int, error) {
-	var port int
-	_, err := fmt.Sscanf(s, "%d", &port)
+	port, err := strconv.Atoi(s)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("invalid port %q: %w", s, err)
 	}
 	if port < 1 || port > 65535 {
 		return 0, fmt.Errorf("port out of range: %d", port)
@@ -421,12 +423,13 @@ func parsePort(s string) (int, error) {
 	return port, nil
 }
 
-// parsePositiveInt attempts to parse a string as a positive integer.
+// parsePositiveInt attempts to parse a string as a non-negative integer.
+// The entire string must be a base-10 integer; leading/trailing whitespace,
+// sign prefixes, or any non-digit suffix are rejected (see T-654).
 func parsePositiveInt(s string) (int, error) {
-	var n int
-	_, err := fmt.Sscanf(s, "%d", &n)
+	n, err := strconv.Atoi(s)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("invalid integer %q: %w", s, err)
 	}
 	if n < 0 {
 		return 0, fmt.Errorf("value must be non-negative: %d", n)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -311,7 +311,7 @@ func Load(workingDir string) *Config {
 			servePort = port
 			envUsed = true
 		} else {
-			fmt.Fprintf(os.Stderr, "Warning: ORBIT_SERVE_PORT=%q ignored: %v\n", envServePort, err)
+			log.Printf("Warning: ORBIT_SERVE_PORT=%q ignored: %v", envServePort, err)
 		}
 	}
 	if envServeBind, exists := os.LookupEnv("ORBIT_SERVE_BIND"); exists {
@@ -332,7 +332,7 @@ func Load(workingDir string) *Config {
 			variantCount = count
 			envUsed = true
 		} else {
-			fmt.Fprintf(os.Stderr, "Warning: ORBIT_VARIANT_COUNT=%q ignored: %v\n", envVariantCount, err)
+			log.Printf("Warning: ORBIT_VARIANT_COUNT=%q ignored: %v", envVariantCount, err)
 		}
 	}
 	if envParallel, exists := os.LookupEnv("ORBIT_PARALLEL"); exists {
@@ -344,7 +344,7 @@ func Load(workingDir string) *Config {
 			maxParallel = max
 			envUsed = true
 		} else {
-			fmt.Fprintf(os.Stderr, "Warning: ORBIT_MAX_PARALLEL=%q ignored: %v\n", envMaxParallel, err)
+			log.Printf("Warning: ORBIT_MAX_PARALLEL=%q ignored: %v", envMaxParallel, err)
 		}
 	}
 	if envBranchPrefix, exists := os.LookupEnv("ORBIT_BRANCH_PREFIX"); exists {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -418,6 +418,9 @@ func Load(workingDir string) *Config {
 // The entire string must be unsigned base-10 digits; leading/trailing
 // whitespace, sign prefixes, and any non-digit suffix are rejected.
 func parsePort(s string) (int, error) {
+	// strconv.Atoi accepts a leading '+' or '-' (it wraps ParseInt with base 10).
+	// Reject those explicitly so port values are required to be plain unsigned
+	// digits — do not remove without also switching to ParseUint.
 	if s == "" || s[0] == '+' || s[0] == '-' {
 		return 0, fmt.Errorf("invalid port %q: must be unsigned base-10 digits", s)
 	}
@@ -435,6 +438,9 @@ func parsePort(s string) (int, error) {
 // The entire string must be unsigned base-10 digits; leading/trailing
 // whitespace, sign prefixes, and any non-digit suffix are rejected.
 func parsePositiveInt(s string) (int, error) {
+	// strconv.Atoi accepts a leading '+' or '-' (it wraps ParseInt with base 10).
+	// Reject those explicitly so the value is required to be plain unsigned
+	// digits — do not remove without also switching to ParseUint.
 	if s == "" || s[0] == '+' || s[0] == '-' {
 		return 0, fmt.Errorf("invalid integer %q: must be unsigned base-10 digits", s)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -310,8 +310,9 @@ func Load(workingDir string) *Config {
 		if port, err := parsePort(envServePort); err == nil {
 			servePort = port
 			envUsed = true
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: ORBIT_SERVE_PORT=%q ignored: %v\n", envServePort, err)
 		}
-		// Invalid port values are silently ignored (use config/default)
 	}
 	if envServeBind, exists := os.LookupEnv("ORBIT_SERVE_BIND"); exists {
 		serveBind = envServeBind
@@ -330,6 +331,8 @@ func Load(workingDir string) *Config {
 		if count, err := parsePositiveInt(envVariantCount); err == nil {
 			variantCount = count
 			envUsed = true
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: ORBIT_VARIANT_COUNT=%q ignored: %v\n", envVariantCount, err)
 		}
 	}
 	if envParallel, exists := os.LookupEnv("ORBIT_PARALLEL"); exists {
@@ -340,6 +343,8 @@ func Load(workingDir string) *Config {
 		if max, err := parsePositiveInt(envMaxParallel); err == nil {
 			maxParallel = max
 			envUsed = true
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: ORBIT_MAX_PARALLEL=%q ignored: %v\n", envMaxParallel, err)
 		}
 	}
 	if envBranchPrefix, exists := os.LookupEnv("ORBIT_BRANCH_PREFIX"); exists {
@@ -410,9 +415,12 @@ func Load(workingDir string) *Config {
 }
 
 // parsePort attempts to parse a string as a valid port number.
-// The entire string must be a base-10 integer; leading/trailing whitespace,
-// sign prefixes, or any non-digit suffix are rejected (see T-654).
+// The entire string must be unsigned base-10 digits; leading/trailing
+// whitespace, sign prefixes, and any non-digit suffix are rejected.
 func parsePort(s string) (int, error) {
+	if s == "" || s[0] == '+' || s[0] == '-' {
+		return 0, fmt.Errorf("invalid port %q: must be unsigned base-10 digits", s)
+	}
 	port, err := strconv.Atoi(s)
 	if err != nil {
 		return 0, fmt.Errorf("invalid port %q: %w", s, err)
@@ -424,15 +432,15 @@ func parsePort(s string) (int, error) {
 }
 
 // parsePositiveInt attempts to parse a string as a non-negative integer.
-// The entire string must be a base-10 integer; leading/trailing whitespace,
-// sign prefixes, or any non-digit suffix are rejected (see T-654).
+// The entire string must be unsigned base-10 digits; leading/trailing
+// whitespace, sign prefixes, and any non-digit suffix are rejected.
 func parsePositiveInt(s string) (int, error) {
+	if s == "" || s[0] == '+' || s[0] == '-' {
+		return 0, fmt.Errorf("invalid integer %q: must be unsigned base-10 digits", s)
+	}
 	n, err := strconv.Atoi(s)
 	if err != nil {
 		return 0, fmt.Errorf("invalid integer %q: %w", s, err)
-	}
-	if n < 0 {
-		return 0, fmt.Errorf("value must be non-negative: %d", n)
 	}
 	return n, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2594,3 +2594,117 @@ func TestLoad_AutoConsolidate_ProjectOverridesHome(t *testing.T) {
 		t.Error("expected project config to override home config")
 	}
 }
+
+// Regression tests for T-654: parsePort and parsePositiveInt previously used
+// fmt.Sscanf("%d", ...), which accepts a numeric prefix and ignores trailing
+// characters. Values like "8080abc" or "3oops" were silently accepted as 8080
+// and 3 respectively. Strict parsing should reject any non-numeric trailing
+// or leading characters.
+
+func TestParsePort_RejectsTrailingCharacters(t *testing.T) {
+	cases := []string{
+		"8080abc",
+		"8080 ",
+		" 8080",
+		"8080.0",
+		"8080\n",
+		"0x1F90",
+		"8080garbage",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := parsePort(in); err == nil {
+				t.Errorf("parsePort(%q) should have returned an error", in)
+			}
+		})
+	}
+}
+
+func TestParsePort_AcceptsValidPort(t *testing.T) {
+	got, err := parsePort("8080")
+	if err != nil {
+		t.Fatalf("parsePort(\"8080\") returned error: %v", err)
+	}
+	if got != 8080 {
+		t.Errorf("parsePort(\"8080\") = %d, want 8080", got)
+	}
+}
+
+func TestParsePositiveInt_RejectsTrailingCharacters(t *testing.T) {
+	cases := []string{
+		"3oops",
+		"3 ",
+		" 3",
+		"3.0",
+		"3\n",
+		"3abc",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := parsePositiveInt(in); err == nil {
+				t.Errorf("parsePositiveInt(%q) should have returned an error", in)
+			}
+		})
+	}
+}
+
+func TestParsePositiveInt_AcceptsValidValue(t *testing.T) {
+	got, err := parsePositiveInt("3")
+	if err != nil {
+		t.Fatalf("parsePositiveInt(\"3\") returned error: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("parsePositiveInt(\"3\") = %d, want 3", got)
+	}
+}
+
+func TestLoad_ServePortRejectsTrailingChars(t *testing.T) {
+	tmpDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("ORBIT_SERVE_PORT", "9000abc")
+
+	cfg := Load(tmpDir)
+
+	// Bug: 9000abc was previously accepted as 9000. With the fix, the value
+	// is rejected and the default is used.
+	if cfg.ServePort != DefaultServePort {
+		t.Errorf("expected default ServePort %d for ORBIT_SERVE_PORT=%q, got %d",
+			DefaultServePort, "9000abc", cfg.ServePort)
+	}
+}
+
+func TestLoad_VariantCountRejectsTrailingChars(t *testing.T) {
+	tmpDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("ORBIT_VARIANT_COUNT", "3oops")
+
+	cfg := Load(tmpDir)
+
+	// Bug: 3oops was previously accepted as 3. With the fix, the value is
+	// rejected and the default (0 — feature disabled) is used.
+	if cfg.VariantCount != 0 {
+		t.Errorf("expected VariantCount 0 for ORBIT_VARIANT_COUNT=%q, got %d",
+			"3oops", cfg.VariantCount)
+	}
+}
+
+func TestLoad_MaxParallelRejectsTrailingChars(t *testing.T) {
+	tmpDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("ORBIT_MAX_PARALLEL", "5junk")
+
+	cfg := Load(tmpDir)
+
+	// Bug: 5junk was previously accepted as 5. With the fix, the value is
+	// rejected and the default (DefaultMaxParallel) is used.
+	if cfg.MaxParallel != DefaultMaxParallel {
+		t.Errorf("expected MaxParallel %d for ORBIT_MAX_PARALLEL=%q, got %d",
+			DefaultMaxParallel, "5junk", cfg.MaxParallel)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2696,12 +2696,30 @@ func TestParsePositiveInt_AcceptsValidValue(t *testing.T) {
 	}
 }
 
+// silenceStderr redirects os.Stderr to /dev/null for the duration of the
+// test so the expected "Warning: ORBIT_…" lines from rejected env values
+// do not pollute go test output. The original stderr is restored on cleanup.
+func silenceStderr(t *testing.T) {
+	t.Helper()
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("opening os.DevNull: %v", err)
+	}
+	original := os.Stderr
+	os.Stderr = devNull
+	t.Cleanup(func() {
+		os.Stderr = original
+		_ = devNull.Close()
+	})
+}
+
 func TestLoad_ServePortRejectsTrailingChars(t *testing.T) {
 	tmpDir := t.TempDir()
 	homeDir := t.TempDir()
 
 	t.Setenv("HOME", homeDir)
 	t.Setenv("ORBIT_SERVE_PORT", "9000abc")
+	silenceStderr(t)
 
 	cfg := Load(tmpDir)
 
@@ -2718,6 +2736,7 @@ func TestLoad_VariantCountRejectsTrailingChars(t *testing.T) {
 
 	t.Setenv("HOME", homeDir)
 	t.Setenv("ORBIT_VARIANT_COUNT", "3oops")
+	silenceStderr(t)
 
 	cfg := Load(tmpDir)
 
@@ -2734,6 +2753,7 @@ func TestLoad_MaxParallelRejectsTrailingChars(t *testing.T) {
 
 	t.Setenv("HOME", homeDir)
 	t.Setenv("ORBIT_MAX_PARALLEL", "5junk")
+	silenceStderr(t)
 
 	cfg := Load(tmpDir)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2705,7 +2705,8 @@ func TestParsePositiveInt_AcceptsValidValue(t *testing.T) {
 //
 // This swaps the logger's writer rather than os.Stderr so it does not
 // race with anything else in the process that holds a reference to the
-// original os.Stderr.
+// original os.Stderr. The standard logger's writer is still global state,
+// so callers must not run with t.Parallel().
 func silenceLog(t *testing.T) {
 	t.Helper()
 	original := log.Writer()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2696,20 +2698,20 @@ func TestParsePositiveInt_AcceptsValidValue(t *testing.T) {
 	}
 }
 
-// silenceStderr redirects os.Stderr to /dev/null for the duration of the
-// test so the expected "Warning: ORBIT_…" lines from rejected env values
-// do not pollute go test output. The original stderr is restored on cleanup.
-func silenceStderr(t *testing.T) {
+// silenceLog redirects the standard logger to io.Discard for the duration
+// of the test so the expected "Warning: ORBIT_…" lines from rejected env
+// values do not pollute go test output. The original logger output is
+// restored on cleanup.
+//
+// This swaps the logger's writer rather than os.Stderr so it does not
+// race with anything else in the process that holds a reference to the
+// original os.Stderr.
+func silenceLog(t *testing.T) {
 	t.Helper()
-	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	if err != nil {
-		t.Fatalf("opening os.DevNull: %v", err)
-	}
-	original := os.Stderr
-	os.Stderr = devNull
+	original := log.Writer()
+	log.SetOutput(io.Discard)
 	t.Cleanup(func() {
-		os.Stderr = original
-		_ = devNull.Close()
+		log.SetOutput(original)
 	})
 }
 
@@ -2719,7 +2721,7 @@ func TestLoad_ServePortRejectsTrailingChars(t *testing.T) {
 
 	t.Setenv("HOME", homeDir)
 	t.Setenv("ORBIT_SERVE_PORT", "9000abc")
-	silenceStderr(t)
+	silenceLog(t)
 
 	cfg := Load(tmpDir)
 
@@ -2736,7 +2738,7 @@ func TestLoad_VariantCountRejectsTrailingChars(t *testing.T) {
 
 	t.Setenv("HOME", homeDir)
 	t.Setenv("ORBIT_VARIANT_COUNT", "3oops")
-	silenceStderr(t)
+	silenceLog(t)
 
 	cfg := Load(tmpDir)
 
@@ -2753,7 +2755,7 @@ func TestLoad_MaxParallelRejectsTrailingChars(t *testing.T) {
 
 	t.Setenv("HOME", homeDir)
 	t.Setenv("ORBIT_MAX_PARALLEL", "5junk")
-	silenceStderr(t)
+	silenceLog(t)
 
 	cfg := Load(tmpDir)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2595,11 +2595,8 @@ func TestLoad_AutoConsolidate_ProjectOverridesHome(t *testing.T) {
 	}
 }
 
-// Regression tests for T-654: parsePort and parsePositiveInt previously used
-// fmt.Sscanf("%d", ...), which accepts a numeric prefix and ignores trailing
-// characters. Values like "8080abc" or "3oops" were silently accepted as 8080
-// and 3 respectively. Strict parsing should reject any non-numeric trailing
-// or leading characters.
+// parsePort and parsePositiveInt must reject any input that is not a complete
+// unsigned base-10 integer (no whitespace, sign prefixes, or trailing chars).
 
 func TestParsePort_RejectsTrailingCharacters(t *testing.T) {
 	cases := []string{
@@ -2610,9 +2607,12 @@ func TestParsePort_RejectsTrailingCharacters(t *testing.T) {
 		"8080\n",
 		"0x1F90",
 		"8080garbage",
+		"+8080",
+		"-8080",
+		"",
 	}
 	for _, in := range cases {
-		t.Run(in, func(t *testing.T) {
+		t.Run(fmt.Sprintf("input=%q", in), func(t *testing.T) {
 			if _, err := parsePort(in); err == nil {
 				t.Errorf("parsePort(%q) should have returned an error", in)
 			}
@@ -2621,12 +2621,35 @@ func TestParsePort_RejectsTrailingCharacters(t *testing.T) {
 }
 
 func TestParsePort_AcceptsValidPort(t *testing.T) {
-	got, err := parsePort("8080")
-	if err != nil {
-		t.Fatalf("parsePort(\"8080\") returned error: %v", err)
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"1", 1},
+		{"8080", 8080},
+		{"65535", 65535},
 	}
-	if got != 8080 {
-		t.Errorf("parsePort(\"8080\") = %d, want 8080", got)
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := parsePort(c.in)
+			if err != nil {
+				t.Fatalf("parsePort(%q) returned error: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("parsePort(%q) = %d, want %d", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParsePort_RejectsOutOfRange(t *testing.T) {
+	cases := []string{"0", "65536", "100000"}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := parsePort(in); err == nil {
+				t.Errorf("parsePort(%q) should have returned an error", in)
+			}
+		})
 	}
 }
 
@@ -2638,9 +2661,12 @@ func TestParsePositiveInt_RejectsTrailingCharacters(t *testing.T) {
 		"3.0",
 		"3\n",
 		"3abc",
+		"+3",
+		"-3",
+		"",
 	}
 	for _, in := range cases {
-		t.Run(in, func(t *testing.T) {
+		t.Run(fmt.Sprintf("input=%q", in), func(t *testing.T) {
 			if _, err := parsePositiveInt(in); err == nil {
 				t.Errorf("parsePositiveInt(%q) should have returned an error", in)
 			}
@@ -2649,12 +2675,24 @@ func TestParsePositiveInt_RejectsTrailingCharacters(t *testing.T) {
 }
 
 func TestParsePositiveInt_AcceptsValidValue(t *testing.T) {
-	got, err := parsePositiveInt("3")
-	if err != nil {
-		t.Fatalf("parsePositiveInt(\"3\") returned error: %v", err)
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"0", 0},
+		{"3", 3},
+		{"100", 100},
 	}
-	if got != 3 {
-		t.Errorf("parsePositiveInt(\"3\") = %d, want 3", got)
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := parsePositiveInt(c.in)
+			if err != nil {
+				t.Fatalf("parsePositiveInt(%q) returned error: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("parsePositiveInt(%q) = %d, want %d", c.in, got, c.want)
+			}
+		})
 	}
 }
 
@@ -2667,8 +2705,7 @@ func TestLoad_ServePortRejectsTrailingChars(t *testing.T) {
 
 	cfg := Load(tmpDir)
 
-	// Bug: 9000abc was previously accepted as 9000. With the fix, the value
-	// is rejected and the default is used.
+	// Malformed values are rejected; ServePort falls back to the default.
 	if cfg.ServePort != DefaultServePort {
 		t.Errorf("expected default ServePort %d for ORBIT_SERVE_PORT=%q, got %d",
 			DefaultServePort, "9000abc", cfg.ServePort)
@@ -2684,8 +2721,7 @@ func TestLoad_VariantCountRejectsTrailingChars(t *testing.T) {
 
 	cfg := Load(tmpDir)
 
-	// Bug: 3oops was previously accepted as 3. With the fix, the value is
-	// rejected and the default (0 — feature disabled) is used.
+	// Malformed values are rejected; VariantCount stays at 0 (feature disabled).
 	if cfg.VariantCount != 0 {
 		t.Errorf("expected VariantCount 0 for ORBIT_VARIANT_COUNT=%q, got %d",
 			"3oops", cfg.VariantCount)
@@ -2701,8 +2737,7 @@ func TestLoad_MaxParallelRejectsTrailingChars(t *testing.T) {
 
 	cfg := Load(tmpDir)
 
-	// Bug: 5junk was previously accepted as 5. With the fix, the value is
-	// rejected and the default (DefaultMaxParallel) is used.
+	// Malformed values are rejected; MaxParallel falls back to the default.
 	if cfg.MaxParallel != DefaultMaxParallel {
 		t.Errorf("expected MaxParallel %d for ORBIT_MAX_PARALLEL=%q, got %d",
 			DefaultMaxParallel, "5junk", cfg.MaxParallel)


### PR DESCRIPTION
## Summary

Fixes T-654. `parsePort` and `parsePositiveInt` in `internal/config/config.go` used `fmt.Sscanf("%d", ...)`, which accepts a numeric prefix and silently ignores any trailing text. As a result:

- `ORBIT_SERVE_PORT=8080abc` was accepted as `8080`
- `ORBIT_VARIANT_COUNT=3oops` was accepted as `3`
- `ORBIT_MAX_PARALLEL=5junk` was accepted as `5`

This meant invalid configuration silently applied unintended values instead of being rejected and falling back to defaults.

## Root Cause

`fmt.Sscanf` with the `%d` verb is intentionally lenient: it scans a numeric prefix and stops at the first non-digit character without erroring. This is the wrong API for input validation, where the entire string should be a valid integer.

## Fix

Replaced `fmt.Sscanf` with `strconv.Atoi` in both helpers. `strconv.Atoi` requires the entire string to be a valid base-10 integer and rejects empty input, leading/trailing whitespace, decimal points, hex prefixes, and any non-digit suffix.

## Test plan

- [x] Added regression tests at the parser-helper level covering trailing chars, leading whitespace, decimals, newlines, and hex prefixes
- [x] Added regression tests at the `Load()` level for `ORBIT_SERVE_PORT`, `ORBIT_VARIANT_COUNT`, and `ORBIT_MAX_PARALLEL` confirming malformed values are rejected and defaults apply
- [x] `make test` passes
- [x] `make lint` passes
- [x] `make build` passes