### PR TITLE
Fix T-653: Boolean Flag Reordering Breaks Consolidate/Finalize Positional Args

### DIFF
--- a/cmd/orbit/consolidate.go
+++ b/cmd/orbit/consolidate.go
@@ -47,7 +47,7 @@ func consolidateCommand(args []string) error {
 	}
 
 	// Reorder args so flags come before positional args (Go's flag package requires this)
-	if err := fs.Parse(reorderArgs(args)); err != nil {
+	if err := fs.Parse(reorderArgs(fs, args)); err != nil {
 		return err
 	}
 

--- a/cmd/orbit/finalize.go
+++ b/cmd/orbit/finalize.go
@@ -32,7 +32,7 @@ func finalizeCommand(args []string) error {
 	}
 
 	// Reorder args so flags come before positional args (Go's flag package requires this)
-	if err := fs.Parse(reorderArgs(args)); err != nil {
+	if err := fs.Parse(reorderArgs(fs, args)); err != nil {
 		return err
 	}
 

--- a/cmd/orbit/main.go
+++ b/cmd/orbit/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -110,10 +111,29 @@ func isKnownSubcommand(arg string) bool {
 	return knownSubcommands[arg]
 }
 
-// reorderArgs moves flags before positional arguments.
-// Go's flag package stops parsing at the first non-flag argument,
-// so we need to reorder to support "cmd arg --flag value" syntax.
-func reorderArgs(args []string) []string {
+// boolFlag matches the unexported flag.boolFlag interface used by the standard
+// flag package to identify boolean flags. We rely on the same duck-typed
+// IsBoolFlag method so we can correctly detect bool flags registered on a
+// FlagSet without consuming the next token as a value.
+type boolFlag interface {
+	IsBoolFlag() bool
+}
+
+// reorderArgs moves flags before positional arguments so that a FlagSet can
+// parse them. Go's flag package stops parsing at the first non-flag argument,
+// so reordering supports "cmd positional --flag value" syntax.
+//
+// When fs is non-nil, the FlagSet is consulted to determine whether a flag
+// takes a value. Boolean flags never consume the following token, so a
+// positional argument that follows "--rollback" or "--force" is preserved as
+// a positional rather than being absorbed as the flag's value. This matters
+// for subcommands like "orbit consolidate --rollback my-feature" where the
+// previous heuristic would incorrectly bind "my-feature" to "--rollback".
+//
+// When fs is nil (or the flag is unknown), reorderArgs falls back to the
+// original heuristic: consume the next token as the flag's value if it
+// doesn't start with "-" and the flag isn't already in "--flag=value" form.
+func reorderArgs(fs *flag.FlagSet, args []string) []string {
 	var flags []string
 	var positional []string
 
@@ -122,11 +142,14 @@ func reorderArgs(args []string) []string {
 		arg := args[i]
 		if strings.HasPrefix(arg, "-") {
 			flags = append(flags, arg)
-			// Check if this flag has a value (not a boolean flag)
-			// Heuristic: if next arg exists and doesn't start with -, it's a value
+			// "--flag=value" form already carries its value inline.
+			if strings.Contains(arg, "=") {
+				i++
+				continue
+			}
+			// Decide whether to consume the next token as this flag's value.
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				// Check if it's a flag=value format
-				if !strings.Contains(arg, "=") {
+				if flagTakesValue(fs, arg) {
 					i++
 					flags = append(flags, args[i])
 				}
@@ -138,6 +161,29 @@ func reorderArgs(args []string) []string {
 	}
 
 	return append(flags, positional...)
+}
+
+// flagTakesValue reports whether the flag named in arg (e.g. "--rollback" or
+// "-force") expects a value to follow it. Boolean flags do not. When the
+// FlagSet is nil or the flag is unknown, the function returns true so the
+// previous, less-strict behaviour is preserved for unrecognised flags — the
+// FlagSet will surface a useful error during Parse.
+func flagTakesValue(fs *flag.FlagSet, arg string) bool {
+	if fs == nil {
+		return true
+	}
+	name := strings.TrimLeft(arg, "-")
+	if name == "" {
+		return true
+	}
+	f := fs.Lookup(name)
+	if f == nil {
+		return true
+	}
+	if bf, ok := f.Value.(boolFlag); ok && bf.IsBoolFlag() {
+		return false
+	}
+	return true
 }
 
 // printUsage displays the top-level help message.

--- a/cmd/orbit/main_test.go
+++ b/cmd/orbit/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -174,48 +175,105 @@ func TestDetectTasksFile_FullBranchNameFallback(t *testing.T) {
 	}
 }
 
+// newConsolidateFlagSet builds a FlagSet that mirrors the flags registered by
+// the consolidate subcommand. Tests use it to exercise reorderArgs against a
+// realistic flag definition without coupling to the command's logic.
+func newConsolidateFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("consolidate", flag.ContinueOnError)
+	_ = fs.Int("variant", 0, "")
+	_ = fs.Bool("allow-dirty", false, "")
+	_ = fs.String("prompt", "", "")
+	_ = fs.Bool("rollback", false, "")
+	_ = fs.Bool("force", false, "")
+	return fs
+}
+
+// newFinalizeFlagSet mirrors the finalize subcommand's flag definitions.
+func newFinalizeFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("finalize", flag.ContinueOnError)
+	_ = fs.Int("variant", 0, "")
+	_ = fs.Bool("force", false, "")
+	return fs
+}
+
 func TestReorderArgs(t *testing.T) {
 	tests := map[string]struct {
+		fs       *flag.FlagSet
 		input    []string
 		expected []string
 	}{
 		"flags before positional": {
+			fs:       newConsolidateFlagSet(),
 			input:    []string{"--variant", "1", "my-spec"},
 			expected: []string{"--variant", "1", "my-spec"},
 		},
 		"positional before flags": {
+			fs:       newConsolidateFlagSet(),
 			input:    []string{"my-spec", "--variant", "1"},
 			expected: []string{"--variant", "1", "my-spec"},
 		},
 		"mixed order": {
+			fs:       newConsolidateFlagSet(),
 			input:    []string{"my-spec", "--variant", "1", "--force"},
 			expected: []string{"--variant", "1", "--force", "my-spec"},
 		},
 		"boolean flag between positional and value flag": {
+			fs:       newConsolidateFlagSet(),
 			input:    []string{"my-spec", "--force", "--variant", "1"},
 			expected: []string{"--force", "--variant", "1", "my-spec"},
 		},
 		"flag with equals": {
+			fs:       newConsolidateFlagSet(),
 			input:    []string{"my-spec", "--variant=1"},
 			expected: []string{"--variant=1", "my-spec"},
 		},
 		"only flags": {
+			fs:       newConsolidateFlagSet(),
 			input:    []string{"--variant", "1", "--force"},
 			expected: []string{"--variant", "1", "--force"},
 		},
 		"only positional": {
+			fs:       newConsolidateFlagSet(),
 			input:    []string{"my-spec", "another-arg"},
 			expected: []string{"my-spec", "another-arg"},
 		},
 		"empty": {
+			fs:       newConsolidateFlagSet(),
 			input:    []string{},
 			expected: []string{},
+		},
+		// Regression tests for T-653: boolean flags must not consume the
+		// following positional argument.
+		"T-653: --rollback then positional": {
+			fs:       newConsolidateFlagSet(),
+			input:    []string{"--rollback", "my-feature"},
+			expected: []string{"--rollback", "my-feature"},
+		},
+		"T-653: --force then positional then value flag (finalize)": {
+			fs:       newFinalizeFlagSet(),
+			input:    []string{"--force", "my-feature", "--variant", "1"},
+			expected: []string{"--force", "--variant", "1", "my-feature"},
+		},
+		"T-653: --allow-dirty then positional": {
+			fs:       newConsolidateFlagSet(),
+			input:    []string{"--allow-dirty", "my-feature", "--variant", "2"},
+			expected: []string{"--allow-dirty", "--variant", "2", "my-feature"},
+		},
+		"T-653: short bool flag then positional": {
+			fs: func() *flag.FlagSet {
+				fs := flag.NewFlagSet("t", flag.ContinueOnError)
+				_ = fs.Bool("v", false, "")
+				_ = fs.Int("variant", 0, "")
+				return fs
+			}(),
+			input:    []string{"-v", "my-feature", "--variant", "1"},
+			expected: []string{"-v", "--variant", "1", "my-feature"},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := reorderArgs(tc.input)
+			got := reorderArgs(tc.fs, tc.input)
 			if len(got) != len(tc.expected) {
 				t.Errorf("got %v, want %v", got, tc.expected)
 				return
@@ -227,6 +285,137 @@ func TestReorderArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestReorderArgs_NilFlagSet verifies the legacy heuristic still applies when
+// no FlagSet is provided. This preserves backward compatibility for any
+// future callers that don't have a FlagSet handy.
+func TestReorderArgs_NilFlagSet(t *testing.T) {
+	tests := map[string]struct {
+		input    []string
+		expected []string
+	}{
+		"nil fs falls back to consume-next heuristic": {
+			input:    []string{"my-spec", "--variant", "1"},
+			expected: []string{"--variant", "1", "my-spec"},
+		},
+		"nil fs gobbles next token even for what would be a bool": {
+			// Without a FlagSet the function cannot know --rollback is bool.
+			// The legacy heuristic consumes the following token; that's why
+			// callers should pass a FlagSet whenever bool flags exist.
+			input:    []string{"--rollback", "my-spec"},
+			expected: []string{"--rollback", "my-spec"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := reorderArgs(nil, tc.input)
+			if len(got) != len(tc.expected) {
+				t.Errorf("got %v, want %v", got, tc.expected)
+				return
+			}
+			for i := range got {
+				if got[i] != tc.expected[i] {
+					t.Errorf("got %v, want %v", got, tc.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestReorderArgs_ConsolidatePositionalAfterBoolFlag verifies the end-to-end
+// behaviour reported in T-653: invocations like
+// `orbit consolidate --rollback my-feature` and
+// `orbit consolidate --allow-dirty my-feature --variant 1` must parse with
+// `my-feature` as the positional argument and the bool flag set, without
+// dropping the value flag (`--variant 1`).
+func TestReorderArgs_ConsolidatePositionalAfterBoolFlag(t *testing.T) {
+	tests := map[string]struct {
+		args         []string
+		wantSpec     string
+		wantVariant  int
+		wantRollback bool
+		wantDirty    bool
+		wantForce    bool
+	}{
+		"--rollback then spec name": {
+			args:         []string{"--rollback", "my-feature"},
+			wantSpec:     "my-feature",
+			wantRollback: true,
+		},
+		"--allow-dirty then spec then --variant": {
+			args:        []string{"--allow-dirty", "my-feature", "--variant", "1"},
+			wantSpec:    "my-feature",
+			wantVariant: 1,
+			wantDirty:   true,
+		},
+		"--force then spec then --variant": {
+			args:        []string{"--force", "my-feature", "--variant", "2"},
+			wantSpec:    "my-feature",
+			wantVariant: 2,
+			wantForce:   true,
+		},
+		"spec then --rollback (already worked)": {
+			args:         []string{"my-feature", "--rollback"},
+			wantSpec:     "my-feature",
+			wantRollback: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fs := flag.NewFlagSet("consolidate", flag.ContinueOnError)
+			variant := fs.Int("variant", 0, "")
+			allowDirty := fs.Bool("allow-dirty", false, "")
+			rollback := fs.Bool("rollback", false, "")
+			force := fs.Bool("force", false, "")
+
+			if err := fs.Parse(reorderArgs(fs, tc.args)); err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+
+			if got := fs.Arg(0); got != tc.wantSpec {
+				t.Errorf("spec: got %q, want %q", got, tc.wantSpec)
+			}
+			if *variant != tc.wantVariant {
+				t.Errorf("variant: got %d, want %d", *variant, tc.wantVariant)
+			}
+			if *rollback != tc.wantRollback {
+				t.Errorf("rollback: got %v, want %v", *rollback, tc.wantRollback)
+			}
+			if *allowDirty != tc.wantDirty {
+				t.Errorf("allow-dirty: got %v, want %v", *allowDirty, tc.wantDirty)
+			}
+			if *force != tc.wantForce {
+				t.Errorf("force: got %v, want %v", *force, tc.wantForce)
+			}
+		})
+	}
+}
+
+// TestReorderArgs_FinalizePositionalAfterBoolFlag exercises the finalize
+// subcommand's flag set — the second example called out in T-653.
+func TestReorderArgs_FinalizePositionalAfterBoolFlag(t *testing.T) {
+	args := []string{"--force", "my-feature", "--variant", "1"}
+
+	fs := flag.NewFlagSet("finalize", flag.ContinueOnError)
+	variant := fs.Int("variant", 0, "")
+	force := fs.Bool("force", false, "")
+
+	if err := fs.Parse(reorderArgs(fs, args)); err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	if got := fs.Arg(0); got != "my-feature" {
+		t.Errorf("spec: got %q, want %q", got, "my-feature")
+	}
+	if *variant != 1 {
+		t.Errorf("variant: got %d, want 1", *variant)
+	}
+	if !*force {
+		t.Error("force: got false, want true")
 	}
 }
 

--- a/cmd/orbit/main_test.go
+++ b/cmd/orbit/main_test.go
@@ -227,6 +227,20 @@ func TestReorderArgs(t *testing.T) {
 			input:    []string{"my-spec", "--variant=1"},
 			expected: []string{"--variant=1", "my-spec"},
 		},
+		// Regression guard for the i++; continue branch in reorderArgs:
+		// "--flag=value" must not absorb the following positional argument.
+		"equals-flag before positional": {
+			fs:       newConsolidateFlagSet(),
+			input:    []string{"--variant=1", "my-feature"},
+			expected: []string{"--variant=1", "my-feature"},
+		},
+		// Multiple boolean flags in sequence followed by a positional. Each
+		// bool must keep its hands off the following token.
+		"sequential bool flags then positional": {
+			fs:       newConsolidateFlagSet(),
+			input:    []string{"--allow-dirty", "--rollback", "my-spec"},
+			expected: []string{"--allow-dirty", "--rollback", "my-spec"},
+		},
 		"only flags": {
 			fs:       newConsolidateFlagSet(),
 			input:    []string{"--variant", "1", "--force"},
@@ -301,9 +315,14 @@ func TestReorderArgs_NilFlagSet(t *testing.T) {
 			expected: []string{"--variant", "1", "my-spec"},
 		},
 		"nil fs gobbles next token even for what would be a bool": {
-			// Without a FlagSet the function cannot know --rollback is bool.
-			// The legacy heuristic consumes the following token; that's why
-			// callers should pass a FlagSet whenever bool flags exist.
+			// Without a FlagSet the function cannot know --rollback is bool,
+			// so the legacy heuristic consumes "my-spec" as if it were
+			// --rollback's value. The combined output here is coincidentally
+			// correct because "my-spec" is appended to flags rather than
+			// positional, but a value flag following the absorbed token would
+			// be lost — e.g. ["--rollback", "my-spec", "--variant", "1"]
+			// would drop --variant entirely. Callers should always pass a
+			// FlagSet when bool flags exist.
 			input:    []string{"--rollback", "my-spec"},
 			expected: []string{"--rollback", "my-spec"},
 		},


### PR DESCRIPTION
## Summary

Fixes T-653. `cmd/orbit/main.go`'s `reorderArgs` assumed every flag without an `=` form consumed the next token as its value. For boolean flags this bound the next positional to the bool and then dropped any value flags that followed.

- `orbit finalize --force my-feature --variant 1` previously lost `--variant 1` because `my-feature` was glued to `--force`, leaving `[my-feature --variant 1]` in `fs.Args()`.
- `orbit consolidate --allow-dirty my-feature --variant 2` failed the same way.
- `orbit consolidate --rollback my-feature` survived only by accident — Go's `flag` parser doesn't accept space-separated values for booleans, but the reorder still misclassified `my-feature` as a flag value.

## Fix

`reorderArgs` now accepts a `*flag.FlagSet` and uses the standard `IsBoolFlag()` duck-type interface to detect boolean flags. When the next token follows a boolean flag, it is left as a positional. Unknown flags fall back to the legacy heuristic so `flag.Parse` still produces useful errors. `consolidate` and `finalize` pass their FlagSet through.

`cleanup` also has bool flags but doesn't call `reorderArgs` today; that is a separate, pre-existing issue and out of scope for this ticket.

## Test plan

- [x] `go test ./cmd/orbit/ -run TestReorderArgs -v` (new regression cases for `--rollback`, `--force`, `--allow-dirty`, short bool flag)
- [x] `make test`
- [x] `make build`
- [x] `make lint`
- [x] Manual smoke: `./orbit consolidate --rollback nonexistent-spec` and `./orbit finalize --force nonexistent-spec --variant 1` now reach the spec-name validation step rather than failing in flag parsing.