### PR TITLE
Fix T-728: Validate Resolved max-parallel Value

### DIFF
--- a/cmd/orbit/run.go
+++ b/cmd/orbit/run.go
@@ -58,7 +58,7 @@ func runCommand(args []string) error {
 	// Variant flags for multi-spec comparison
 	variantCount := fs.Int("variants", 0, "Number of implementation variants to run (0 = single-run mode)")
 	parallel := fs.Bool("parallel", false, "Run variants in parallel")
-	maxParallel := fs.Int("max-parallel", 3, "Maximum parallel variants")
+	maxParallel := fs.Int("max-parallel", config.DefaultMaxParallel, "Maximum parallel variants")
 	branchPrefix := fs.String("branch-prefix", "orbit-impl", "Branch naming prefix for variants")
 	guidanceFile := fs.String("guidance-file", "", "YAML file with per-variant guidance")
 	compareCommand := fs.String("compare-command", "", "Custom comparison command")
@@ -204,17 +204,16 @@ func runCommand(args []string) error {
 		parallelValue = true
 	}
 
-	// Resolve and validate max-parallel.
-	// Validation operates on the resolved value (not the raw CLI flag) so a
-	// negative `.orbit.yaml` value cannot bypass the check just because the
-	// flag holds its default — see T-728.
+	// Resolve and validate max-parallel. Validation operates on the resolved
+	// value (not the raw CLI flag) so a negative `.orbit.yaml` value cannot
+	// bypass the check just because the flag holds its default.
 	maxParallelExplicit := false
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "max-parallel" {
 			maxParallelExplicit = true
 		}
 	})
-	maxParallelValue, err := resolveMaxParallel(cfg.MaxParallel, *maxParallel, 3, maxParallelExplicit)
+	maxParallelValue, err := resolveMaxParallel(cfg.MaxParallel, *maxParallel, maxParallelExplicit)
 	if err != nil {
 		return err
 	}
@@ -249,7 +248,7 @@ func runCommand(args []string) error {
 	}
 
 	// Validate variant configuration. Max-parallel is validated inside
-	// resolveMaxParallel so config-sourced values are also checked (T-728).
+	// resolveMaxParallel so config-sourced values are also checked.
 	if *variantCount < 0 {
 		return fmt.Errorf("--variants must be non-negative")
 	}
@@ -343,20 +342,21 @@ func getGitBranch() (string, error) {
 // resolveMaxParallel applies CLI/config precedence to --max-parallel and
 // validates the resolved value. The flag must be detected as explicitly set
 // via fs.Visit so an explicit --max-parallel=3 still wins over a non-default
-// config value (T-585 regression).
+// config value.
 //
 // Precedence: explicit flag > config > flag default. A config value of 0 is
-// treated as "unset" and falls through to the flag default; an explicit
-// --max-parallel=0 is left at 0 so validation rejects it. Validation runs on
-// the *resolved* value so a negative `.orbit.yaml` value cannot bypass the
-// check just because the flag held its built-in default (T-728 regression).
-func resolveMaxParallel(configValue, flagValue, flagDefault int, flagExplicit bool) (int, error) {
+// treated as "unset" and falls through to the flag's default (which flagValue
+// already holds when flagExplicit is false). An explicit --max-parallel=0 is
+// left at 0 so validation rejects it. Validation runs on the *resolved* value
+// so a negative `.orbit.yaml` value cannot bypass the check just because the
+// flag held its built-in default.
+func resolveMaxParallel(configValue, flagValue int, flagExplicit bool) (int, error) {
 	var resolved int
 	switch {
 	case flagExplicit:
 		resolved = flagValue
 	case configValue == 0:
-		resolved = flagDefault
+		resolved = flagValue // flag holds its default when not explicitly set
 	default:
 		resolved = configValue
 	}

--- a/cmd/orbit/run.go
+++ b/cmd/orbit/run.go
@@ -204,22 +204,19 @@ func runCommand(args []string) error {
 		parallelValue = true
 	}
 
-	// Resolve max-parallel: CLI flag overrides config if explicitly provided.
-	// Use fs.Visit to detect whether the flag was actually set on the command line,
-	// so that --max-parallel=3 (matching the default) still overrides config.
+	// Resolve and validate max-parallel.
+	// Validation operates on the resolved value (not the raw CLI flag) so a
+	// negative `.orbit.yaml` value cannot bypass the check just because the
+	// flag holds its default — see T-728.
 	maxParallelExplicit := false
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "max-parallel" {
 			maxParallelExplicit = true
 		}
 	})
-	maxParallelValue := cfg.MaxParallel
-	if maxParallelExplicit {
-		maxParallelValue = *maxParallel
-	}
-	// If config value is 0 and flag wasn't explicitly set, use the built-in default
-	if maxParallelValue == 0 {
-		maxParallelValue = *maxParallel
+	maxParallelValue, err := resolveMaxParallel(cfg.MaxParallel, *maxParallel, 3, maxParallelExplicit)
+	if err != nil {
+		return err
 	}
 
 	// Resolve auto-consolidate: --auto-consolidate enables, --no-auto-consolidate disables
@@ -251,12 +248,10 @@ func runCommand(args []string) error {
 		}
 	}
 
-	// Validate variant configuration
+	// Validate variant configuration. Max-parallel is validated inside
+	// resolveMaxParallel so config-sourced values are also checked (T-728).
 	if *variantCount < 0 {
 		return fmt.Errorf("--variants must be non-negative")
-	}
-	if *maxParallel < 1 {
-		return fmt.Errorf("--max-parallel must be at least 1")
 	}
 
 	// Validate auto-consolidate requires variants
@@ -343,6 +338,32 @@ func getGitBranch() (string, error) {
 		return "", fmt.Errorf("not in a git repository or git not available: %w", err)
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// resolveMaxParallel applies CLI/config precedence to --max-parallel and
+// validates the resolved value. The flag must be detected as explicitly set
+// via fs.Visit so an explicit --max-parallel=3 still wins over a non-default
+// config value (T-585 regression).
+//
+// Precedence: explicit flag > config > flag default. A config value of 0 is
+// treated as "unset" and falls through to the flag default; an explicit
+// --max-parallel=0 is left at 0 so validation rejects it. Validation runs on
+// the *resolved* value so a negative `.orbit.yaml` value cannot bypass the
+// check just because the flag held its built-in default (T-728 regression).
+func resolveMaxParallel(configValue, flagValue, flagDefault int, flagExplicit bool) (int, error) {
+	var resolved int
+	switch {
+	case flagExplicit:
+		resolved = flagValue
+	case configValue == 0:
+		resolved = flagDefault
+	default:
+		resolved = configValue
+	}
+	if resolved < 1 {
+		return 0, fmt.Errorf("--max-parallel must be at least 1 (got %d)", resolved)
+	}
+	return resolved, nil
 }
 
 // resolvePrompts applies CLI flag overrides to config values.

--- a/cmd/orbit/run_test.go
+++ b/cmd/orbit/run_test.go
@@ -177,50 +177,43 @@ func TestAutoConsolidate_AllowDirtyFlag(t *testing.T) {
 // TestMaxParallel_FlagResolution tests that --max-parallel CLI flag properly overrides config,
 // including the case where the explicit value matches the built-in default (3).
 func TestMaxParallel_FlagResolution(t *testing.T) {
-	tests := []struct {
-		name         string
+	tests := map[string]struct {
 		configValue  int
 		flagExplicit bool
 		flagValue    int
 		want         int
 	}{
-		{
-			name:         "config only, no flag",
+		"config only, no flag": {
 			configValue:  8,
 			flagExplicit: false,
 			flagValue:    3, // default
 			want:         8,
 		},
-		{
-			name:         "explicit flag overrides config with non-default",
+		"explicit flag overrides config with non-default": {
 			configValue:  8,
 			flagExplicit: true,
 			flagValue:    5,
 			want:         5,
 		},
-		{
-			name:         "explicit flag=3 overrides config (T-585 regression)",
+		"explicit flag=3 overrides config": {
 			configValue:  8,
 			flagExplicit: true,
 			flagValue:    3,
 			want:         3,
 		},
-		{
-			name:         "config 0 falls back to flag default",
+		"config 0 falls back to flag default": {
 			configValue:  0,
 			flagExplicit: false,
 			flagValue:    3,
 			want:         3,
 		},
-		{
-			name:         "explicit flag=1 overrides config",
+		"explicit flag=1 overrides config": {
 			configValue:  5,
 			flagExplicit: true,
 			flagValue:    1,
 			want:         1,
 		},
-		{
-			name:         "config value used when flag not set",
+		"config value used when flag not set": {
 			configValue:  10,
 			flagExplicit: false,
 			flagValue:    3,
@@ -228,19 +221,14 @@ func TestMaxParallel_FlagResolution(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Simulate the resolution logic from run.go
-			maxParallelValue := tt.configValue
-			if tt.flagExplicit {
-				maxParallelValue = tt.flagValue
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := resolveMaxParallel(tc.configValue, tc.flagValue, tc.flagExplicit)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
-			if maxParallelValue == 0 {
-				maxParallelValue = tt.flagValue
-			}
-
-			if maxParallelValue != tt.want {
-				t.Errorf("maxParallelValue = %d, want %d", maxParallelValue, tt.want)
+			if got != tc.want {
+				t.Errorf("maxParallelValue = %d, want %d", got, tc.want)
 			}
 		})
 	}
@@ -249,44 +237,39 @@ func TestMaxParallel_FlagResolution(t *testing.T) {
 // TestMaxParallel_FlagVisitDetection tests that fs.Visit correctly detects
 // an explicitly set --max-parallel flag, even when its value equals the default.
 func TestMaxParallel_FlagVisitDetection(t *testing.T) {
-	tests := []struct {
-		name         string
+	tests := map[string]struct {
 		args         []string
 		wantExplicit bool
 		wantValue    int
 	}{
-		{
-			name:         "no flag set",
+		"no flag set": {
 			args:         []string{},
 			wantExplicit: false,
 			wantValue:    3, // default
 		},
-		{
-			name:         "explicit non-default value",
+		"explicit non-default value": {
 			args:         []string{"--max-parallel", "5"},
 			wantExplicit: true,
 			wantValue:    5,
 		},
-		{
-			name:         "explicit default value (T-585 regression)",
+		"explicit default value": {
 			args:         []string{"--max-parallel", "3"},
 			wantExplicit: true,
 			wantValue:    3,
 		},
-		{
-			name:         "explicit value with equals syntax",
+		"explicit value with equals syntax": {
 			args:         []string{"--max-parallel=7"},
 			wantExplicit: true,
 			wantValue:    7,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			maxParallel := fs.Int("max-parallel", 3, "Maximum parallel variants")
 
-			if err := fs.Parse(tt.args); err != nil {
+			if err := fs.Parse(tc.args); err != nil {
 				t.Fatalf("failed to parse flags: %v", err)
 			}
 
@@ -297,25 +280,22 @@ func TestMaxParallel_FlagVisitDetection(t *testing.T) {
 				}
 			})
 
-			if explicit != tt.wantExplicit {
-				t.Errorf("explicit = %v, want %v", explicit, tt.wantExplicit)
+			if explicit != tc.wantExplicit {
+				t.Errorf("explicit = %v, want %v", explicit, tc.wantExplicit)
 			}
-			if *maxParallel != tt.wantValue {
-				t.Errorf("maxParallel = %d, want %d", *maxParallel, tt.wantValue)
+			if *maxParallel != tc.wantValue {
+				t.Errorf("maxParallel = %d, want %d", *maxParallel, tc.wantValue)
 			}
 
-			// Now simulate the full resolution with a config value of 8
+			// Verify the helper resolves to the expected value when a
+			// non-zero config value would otherwise win.
 			configValue := 8
-			resolved := configValue
-			if explicit {
-				resolved = *maxParallel
+			resolved, err := resolveMaxParallel(configValue, *maxParallel, explicit)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
-			if resolved == 0 {
-				resolved = *maxParallel
-			}
-
-			if explicit && resolved != tt.wantValue {
-				t.Errorf("resolved = %d, want %d (explicit flag should win)", resolved, tt.wantValue)
+			if explicit && resolved != tc.wantValue {
+				t.Errorf("resolved = %d, want %d (explicit flag should win)", resolved, tc.wantValue)
 			}
 			if !explicit && resolved != configValue {
 				t.Errorf("resolved = %d, want %d (config should win when flag not set)", resolved, configValue)
@@ -325,89 +305,73 @@ func TestMaxParallel_FlagVisitDetection(t *testing.T) {
 }
 
 // TestResolveMaxParallel covers resolution and validation of the --max-parallel
-// flag against config/CLI precedence, including the T-728 regression where a
-// negative `.orbit.yaml` value bypassed validation when the flag was not set.
+// flag against config/CLI precedence, including the regression where a negative
+// `.orbit.yaml` value bypassed validation when the flag was not set.
 //
 // The validation must operate on the *resolved* value rather than the raw CLI
 // flag value. Otherwise a negative config such as `max-parallel: -1` flows
 // through to `make(chan struct{}, n)` and panics with "makechan: size out of
 // range".
 func TestResolveMaxParallel(t *testing.T) {
-	tests := []struct {
-		name         string
+	tests := map[string]struct {
 		configValue  int
 		flagExplicit bool
 		flagValue    int
-		flagDefault  int
 		want         int
 		wantErr      bool
 	}{
-		{
-			name:         "negative config without explicit flag is rejected (T-728)",
+		"negative config without explicit flag is rejected": {
 			configValue:  -1,
 			flagExplicit: false,
 			flagValue:    3,
-			flagDefault:  3,
 			wantErr:      true,
 		},
-		{
-			name:         "negative explicit flag is rejected",
+		"negative explicit flag is rejected": {
 			configValue:  3,
 			flagExplicit: true,
 			flagValue:    -2,
-			flagDefault:  3,
 			wantErr:      true,
 		},
-		{
-			name:         "explicit zero flag is rejected",
+		"explicit zero flag is rejected": {
 			configValue:  3,
 			flagExplicit: true,
 			flagValue:    0,
-			flagDefault:  3,
 			wantErr:      true,
 		},
-		{
-			name:         "zero config falls back to flag default and is valid",
+		"zero config falls back to flag default and is valid": {
 			configValue:  0,
 			flagExplicit: false,
 			flagValue:    3,
-			flagDefault:  3,
 			want:         3,
 			wantErr:      false,
 		},
-		{
-			name:         "valid positive config with no flag",
+		"valid positive config with no flag": {
 			configValue:  4,
 			flagExplicit: false,
 			flagValue:    3,
-			flagDefault:  3,
 			want:         4,
 			wantErr:      false,
 		},
-		{
-			name:         "explicit flag overrides config",
+		"explicit flag overrides config": {
 			configValue:  8,
 			flagExplicit: true,
 			flagValue:    5,
-			flagDefault:  3,
 			want:         5,
 			wantErr:      false,
 		},
-		{
-			name:         "explicit positive flag rescues negative config",
+		"explicit positive flag rescues negative config": {
 			configValue:  -5,
 			flagExplicit: true,
 			flagValue:    2,
-			flagDefault:  3,
 			want:         2,
 			wantErr:      false,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveMaxParallel(tt.configValue, tt.flagValue, tt.flagDefault, tt.flagExplicit)
-			if tt.wantErr {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := resolveMaxParallel(tc.configValue, tc.flagValue, tc.flagExplicit)
+			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected validation error, got nil (resolved=%d)", got)
 				}
@@ -416,8 +380,8 @@ func TestResolveMaxParallel(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tt.want {
-				t.Errorf("resolveMaxParallel = %d, want %d", got, tt.want)
+			if got != tc.want {
+				t.Errorf("resolveMaxParallel = %d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/cmd/orbit/run_test.go
+++ b/cmd/orbit/run_test.go
@@ -324,6 +324,105 @@ func TestMaxParallel_FlagVisitDetection(t *testing.T) {
 	}
 }
 
+// TestResolveMaxParallel covers resolution and validation of the --max-parallel
+// flag against config/CLI precedence, including the T-728 regression where a
+// negative `.orbit.yaml` value bypassed validation when the flag was not set.
+//
+// The validation must operate on the *resolved* value rather than the raw CLI
+// flag value. Otherwise a negative config such as `max-parallel: -1` flows
+// through to `make(chan struct{}, n)` and panics with "makechan: size out of
+// range".
+func TestResolveMaxParallel(t *testing.T) {
+	tests := []struct {
+		name         string
+		configValue  int
+		flagExplicit bool
+		flagValue    int
+		flagDefault  int
+		want         int
+		wantErr      bool
+	}{
+		{
+			name:         "negative config without explicit flag is rejected (T-728)",
+			configValue:  -1,
+			flagExplicit: false,
+			flagValue:    3,
+			flagDefault:  3,
+			wantErr:      true,
+		},
+		{
+			name:         "negative explicit flag is rejected",
+			configValue:  3,
+			flagExplicit: true,
+			flagValue:    -2,
+			flagDefault:  3,
+			wantErr:      true,
+		},
+		{
+			name:         "explicit zero flag is rejected",
+			configValue:  3,
+			flagExplicit: true,
+			flagValue:    0,
+			flagDefault:  3,
+			wantErr:      true,
+		},
+		{
+			name:         "zero config falls back to flag default and is valid",
+			configValue:  0,
+			flagExplicit: false,
+			flagValue:    3,
+			flagDefault:  3,
+			want:         3,
+			wantErr:      false,
+		},
+		{
+			name:         "valid positive config with no flag",
+			configValue:  4,
+			flagExplicit: false,
+			flagValue:    3,
+			flagDefault:  3,
+			want:         4,
+			wantErr:      false,
+		},
+		{
+			name:         "explicit flag overrides config",
+			configValue:  8,
+			flagExplicit: true,
+			flagValue:    5,
+			flagDefault:  3,
+			want:         5,
+			wantErr:      false,
+		},
+		{
+			name:         "explicit positive flag rescues negative config",
+			configValue:  -5,
+			flagExplicit: true,
+			flagValue:    2,
+			flagDefault:  3,
+			want:         2,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveMaxParallel(tt.configValue, tt.flagValue, tt.flagDefault, tt.flagExplicit)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected validation error, got nil (resolved=%d)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveMaxParallel = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestDeprecatedPostCommandFlag tests that --post-command flag is rejected
 func TestDeprecatedPostCommandFlag(t *testing.T) {
 	// The runCommand function checks for deprecated --post-command flag

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,7 +115,7 @@ type Config struct {
 	// Variant configuration for multi-spec comparison
 	VariantCount   int    // Number of variants (0 = single-run mode)
 	Parallel       bool   // Run variants in parallel
-	MaxParallel    int    // Maximum parallel variants
+	MaxParallel    int    // Maximum parallel variants (0 means "unset"; resolved to the CLI flag default)
 	BranchPrefix   string // Branch naming prefix
 	GuidanceFile   string // Path to YAML file with per-variant guidance
 	CompareCommand string // Custom comparison command (empty = use Claude)


### PR DESCRIPTION
## Summary

- Negative `max-parallel: -1` in `.orbit.yaml` previously bypassed validation when the user did not pass `--max-parallel` on the command line, then panicked at `make(chan struct{}, n)` in `runVariantsParallel` with "makechan: size out of range".
- Root cause: validation in `cmd/orbit/run.go` checked the raw CLI flag pointer (`*maxParallel`, default 3) instead of the resolved value that incorporates config precedence.
- Fix: extract resolution and validation into a single `resolveMaxParallel` helper that returns a clear error for any resolved value below 1.

## Changes

- `cmd/orbit/run.go` — Add `resolveMaxParallel(configValue, flagValue, flagDefault, flagExplicit)` helper. Replace the inline resolution block and the broken `*maxParallel < 1` validation with a single call. Behaviour preserved: explicit flag wins; config 0 falls back to flag default; explicit `--max-parallel=0` is left at 0 so validation rejects it.
- `cmd/orbit/run_test.go` — Add `TestResolveMaxParallel` covering the T-728 regression (negative config without explicit flag), zero/negative explicit flag rejection, negative config rescued by an explicit positive flag, and standard precedence cases.

## Test plan

- [x] `go test ./cmd/orbit/ -run TestResolveMaxParallel -v`
- [x] `make test`
- [x] `make lint`
- [ ] Manual: `orbit run --variants 2 --parallel` with `max-parallel: -1` in `.orbit.yaml` returns a clear validation error instead of panicking.

Closes T-728.