### PR TITLE
Fix T-701: Include Copilot Sessions When workspace.yaml Is Missing or Invalid

### DIFF
--- a/docs/agent-notes/apsis-session-listing.md
+++ b/docs/agent-notes/apsis-session-listing.md
@@ -37,6 +37,7 @@ This was the subject of T-146 — `listClaude` previously called `BuildProjectPa
 - Returns `(nil, error)` when the file exists but cannot be read or parsed (callers may surface a warning).
 
 Callers must distinguish "missing metadata" from "invalid session". A session with valid non-empty `events.jsonl` is a valid session even when `workspace.yaml` is missing or malformed; metadata is only needed when filtering by project path. T-701 was caused by the previous `if err != nil || ws == nil { continue }` guard which conflated the two.
+
 ## Codex session structure
 
 Sessions stored in `~/.codex/sessions/YYYY/MM/DD/session-{uuid}.jsonl`.

--- a/docs/agent-notes/apsis-session-listing.md
+++ b/docs/agent-notes/apsis-session-listing.md
@@ -26,9 +26,17 @@ Bug T-290 was caused by `listCopilot` using plain string equality instead of `no
 When `projectPath` is empty (no filtering), each agent source must return ALL sessions:
 - **Claude**: `listClaude` iterates all subdirectories under `~/.claude/projects/` and collects sessions from each. Uses `listClaudeAllProjects()` internally.
 - **Codex**: `listCodex` skips the `cwd` filter check when `projectPath` is empty.
-- **Copilot**: `listCopilot` uses `matchPath != "" && matchPath != projectPath` — when `projectPath` is empty and a session has a known cwd/git_root, `matchPath != ""` is true so the session is skipped. Only sessions without a known workspace path are returned. This is a known limitation (separate from T-146).
+- **Copilot**: `listCopilot` skips the `matchPath` comparison entirely when `projectPath` is empty (T-374). It also includes sessions whose `workspace.yaml` is missing or unparseable when no filter is set (T-701) — workspace metadata is only required for filtering, not for listing. Parse errors are surfaced as `ListWarning` entries.
 
 This was the subject of T-146 — `listClaude` previously called `BuildProjectPath("")` which returned `""`, causing it to look in the root `~/.claude/projects/` directory (which contains subdirectories, not `.jsonl` files).
+
+## Copilot workspace.yaml handling
+
+`parseCopilotWorkspace` in both `internal/sessions/lister.go` and `internal/agents/copilot/agent.go`:
+- Returns `(nil, nil)` when `workspace.yaml` does not exist (treat as missing metadata).
+- Returns `(nil, error)` when the file exists but cannot be read or parsed (callers may surface a warning).
+
+Callers must distinguish "missing metadata" from "invalid session". A session with valid non-empty `events.jsonl` is a valid session even when `workspace.yaml` is missing or malformed; metadata is only needed when filtering by project path. T-701 was caused by the previous `if err != nil || ws == nil { continue }` guard which conflated the two.
 ## Codex session structure
 
 Sessions stored in `~/.codex/sessions/YYYY/MM/DD/session-{uuid}.jsonl`.

--- a/internal/agents/copilot/agent.go
+++ b/internal/agents/copilot/agent.go
@@ -115,7 +115,13 @@ func (a *Agent) DiscoverSessions(ctx context.Context, projectDir string) ([]agen
 		// caller did not request a project filter, the session is still
 		// a valid resumable session and must be returned. Only skip when
 		// we have no metadata AND a project filter is requested.
-		ws, _ := parseCopilotWorkspace(workspacePath)
+		// DiscoverSessions has no warnings channel (unlike sessions.Lister),
+		// so parse errors are emitted via debugLog rather than being
+		// completely invisible.
+		ws, parseErr := parseCopilotWorkspace(workspacePath)
+		if parseErr != nil {
+			debugLog("Failed to parse workspace.yaml for session %s: %v", entry.Name(), parseErr)
+		}
 
 		if projectDir != "" {
 			if ws == nil {

--- a/internal/agents/copilot/agent.go
+++ b/internal/agents/copilot/agent.go
@@ -4,6 +4,7 @@ package copilot
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -109,22 +110,28 @@ func (a *Agent) DiscoverSessions(ctx context.Context, projectDir string) ([]agen
 			continue
 		}
 
-		// Parse workspace.yaml to filter by project directory.
-		ws, err := parseCopilotWorkspace(workspacePath)
-		if err != nil || ws == nil {
-			continue
-		}
+		// Parse workspace.yaml for filtering and timestamp metadata.
+		// A missing or unparseable workspace.yaml is not fatal: when the
+		// caller did not request a project filter, the session is still
+		// a valid resumable session and must be returned. Only skip when
+		// we have no metadata AND a project filter is requested.
+		ws, _ := parseCopilotWorkspace(workspacePath)
 
-		matchPath := ws.GitRoot
-		if matchPath == "" {
-			matchPath = ws.Cwd
-		}
-		if projectDir != "" && matchPath != "" && normalizePath(matchPath) != normalizePath(projectDir) {
-			continue
+		if projectDir != "" {
+			if ws == nil {
+				continue
+			}
+			matchPath := ws.GitRoot
+			if matchPath == "" {
+				matchPath = ws.Cwd
+			}
+			if matchPath != "" && normalizePath(matchPath) != normalizePath(projectDir) {
+				continue
+			}
 		}
 
 		var createdAt time.Time
-		if ws.CreatedAt != nil {
+		if ws != nil && ws.CreatedAt != nil {
 			createdAt = *ws.CreatedAt
 		} else {
 			createdAt = eventsInfo.ModTime()
@@ -151,6 +158,9 @@ type copilotWorkspace struct {
 }
 
 // parseCopilotWorkspace parses a Copilot workspace.yaml file.
+// Returns (nil, nil) when the file does not exist. Returns a non-nil error
+// when the file exists but cannot be read or parsed; callers may choose to
+// surface or ignore that error.
 func parseCopilotWorkspace(path string) (*copilotWorkspace, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -162,7 +172,7 @@ func parseCopilotWorkspace(path string) (*copilotWorkspace, error) {
 
 	var ws copilotWorkspace
 	if err := yaml.Unmarshal(data, &ws); err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("parse workspace.yaml: %w", err)
 	}
 
 	return &ws, nil

--- a/internal/agents/copilot/agent_test.go
+++ b/internal/agents/copilot/agent_test.go
@@ -498,6 +498,127 @@ func TestDiscoverSessions_UsesCreatedAtFromWorkspace(t *testing.T) {
 	}
 }
 
+// TestDiscoverSessions_MissingWorkspaceYAML is a regression test for T-701.
+// A session with a valid non-empty events.jsonl but no workspace.yaml must be
+// returned when no project filter is supplied (projectDir == ""). Previously
+// DiscoverSessions dropped such sessions because parseCopilotWorkspace
+// returned (nil, nil) for missing files and the caller treated ws == nil as
+// "skip".
+func TestDiscoverSessions_MissingWorkspaceYAML(t *testing.T) {
+	homeDir := t.TempDir()
+
+	sessionID := "missing-workspace-session"
+	sessionDir := filepath.Join(homeDir, ".copilot", "session-state", sessionID)
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+	eventsPath := filepath.Join(sessionDir, "events.jsonl")
+	modTime := time.Date(2025, 4, 1, 12, 0, 0, 0, time.UTC)
+	if err := os.WriteFile(eventsPath, []byte(`{"type":"event","data":"test"}`+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write events file: %v", err)
+	}
+	if err := os.Chtimes(eventsPath, modTime, modTime); err != nil {
+		t.Fatalf("failed to set events mtime: %v", err)
+	}
+
+	agent := &Agent{config: agents.AgentConfig{}, cliPath: "copilot", sessionDir: filepath.Join(homeDir, ".copilot", "session-state")}
+
+	sessions, err := agent.DiscoverSessions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("DiscoverSessions() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session with missing workspace.yaml, got %d", len(sessions))
+	}
+	if sessions[0].ID != sessionID {
+		t.Errorf("session.ID = %q, want %q", sessions[0].ID, sessionID)
+	}
+	if !sessions[0].CreatedAt.Equal(modTime) {
+		t.Errorf("CreatedAt = %v, want events mtime %v", sessions[0].CreatedAt, modTime)
+	}
+}
+
+// TestDiscoverSessions_InvalidWorkspaceYAML is a regression test for T-701.
+// A session whose workspace.yaml is unparseable must still be discovered when
+// no project filter is applied.
+func TestDiscoverSessions_InvalidWorkspaceYAML(t *testing.T) {
+	homeDir := t.TempDir()
+
+	sessionID := "invalid-workspace-session"
+	sessionDir := filepath.Join(homeDir, ".copilot", "session-state", sessionID)
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+	eventsPath := filepath.Join(sessionDir, "events.jsonl")
+	if err := os.WriteFile(eventsPath, []byte(`{"type":"event","data":"test"}`+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write events file: %v", err)
+	}
+	bad := []byte("id: \"unterminated\ncwd: : :\n\t- not yaml\n")
+	if err := os.WriteFile(filepath.Join(sessionDir, "workspace.yaml"), bad, 0644); err != nil {
+		t.Fatalf("failed to write workspace file: %v", err)
+	}
+
+	agent := &Agent{config: agents.AgentConfig{}, cliPath: "copilot", sessionDir: filepath.Join(homeDir, ".copilot", "session-state")}
+
+	sessions, err := agent.DiscoverSessions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("DiscoverSessions() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session with invalid workspace.yaml, got %d", len(sessions))
+	}
+	if sessions[0].ID != sessionID {
+		t.Errorf("session.ID = %q, want %q", sessions[0].ID, sessionID)
+	}
+}
+
+// TestDiscoverSessions_MalformedWorkspaceWithFilter ensures that when a
+// project filter is supplied, sessions with missing or invalid workspace
+// metadata do not falsely match. They must be skipped, since there is no
+// metadata to compare against.
+func TestDiscoverSessions_MalformedWorkspaceWithFilter(t *testing.T) {
+	homeDir := t.TempDir()
+	projectPath := t.TempDir()
+
+	modTime := time.Date(2025, 4, 3, 9, 0, 0, 0, time.UTC)
+	// Valid workspace.yaml pointing at projectPath — should match.
+	setupCopilotSession(t, homeDir, projectPath, "valid-session", modTime)
+
+	// Missing workspace.yaml — should be skipped under filter.
+	missingDir := filepath.Join(homeDir, ".copilot", "session-state", "missing-workspace")
+	if err := os.MkdirAll(missingDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(missingDir, "events.jsonl"), []byte(`{"type":"event"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Invalid workspace.yaml — should be skipped under filter.
+	invalidDir := filepath.Join(homeDir, ".copilot", "session-state", "invalid-workspace")
+	if err := os.MkdirAll(invalidDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(invalidDir, "events.jsonl"), []byte(`{"type":"event"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(invalidDir, "workspace.yaml"), []byte("id: \"unterminated\ncwd: : :\n\t- not yaml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := &Agent{config: agents.AgentConfig{}, cliPath: "copilot", sessionDir: filepath.Join(homeDir, ".copilot", "session-state")}
+
+	sessions, err := agent.DiscoverSessions(context.Background(), projectPath)
+	if err != nil {
+		t.Fatalf("DiscoverSessions() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session matching project filter, got %d", len(sessions))
+	}
+	if sessions[0].ID != "valid-session" {
+		t.Errorf("session.ID = %q, want %q", sessions[0].ID, "valid-session")
+	}
+}
+
 func TestAgent_ArgOrder(t *testing.T) {
 	agent := New(agents.AgentConfig{
 		AutoApprove: true,

--- a/internal/sessions/lister.go
+++ b/internal/sessions/lister.go
@@ -43,19 +43,24 @@ func NewLister() (*Lister, error) {
 // sorted by creation time (oldest first).
 // Warnings are returned for agent sources that failed to list.
 func (l *Lister) ListAll(projectPath string) ([]SessionInfo, []ListWarning, error) {
+	var warnings []ListWarning
+
 	collectors := []struct {
 		source string
 		fn     func() ([]SessionInfo, error)
 	}{
 		{SourceClaude, func() ([]SessionInfo, error) { return l.listClaude(projectPath) }},
-		{SourceCopilot, func() ([]SessionInfo, error) { return l.listCopilot(projectPath) }},
+		{SourceCopilot, func() ([]SessionInfo, error) {
+			sessions, parseWarnings, err := l.listCopilot(projectPath)
+			warnings = append(warnings, parseWarnings...)
+			return sessions, err
+		}},
 		{SourceCodex, func() ([]SessionInfo, error) { return l.listCodex(projectPath) }},
 		{SourceKiroCLI, func() ([]SessionInfo, error) { return l.listKiro(projectPath) }},
 		{SourceKiroIDE, func() ([]SessionInfo, error) { return l.listKiroIDE(projectPath) }},
 	}
 
 	var allSessions []SessionInfo
-	var warnings []ListWarning
 
 	for _, c := range collectors {
 		sessions, err := c.fn()
@@ -229,20 +234,25 @@ func (l *Lister) listCodex(projectPath string) ([]SessionInfo, error) {
 	return sessions, nil
 }
 
-// listCopilot returns all Copilot sessions for a project directory.
-func (l *Lister) listCopilot(projectPath string) ([]SessionInfo, error) {
+// listCopilot returns all Copilot sessions for a project directory. When
+// projectPath is empty, sessions with a missing or unparseable workspace.yaml
+// are still returned, since workspace metadata is only needed for filtering.
+// YAML parse failures are surfaced as warnings rather than silently dropping
+// the session.
+func (l *Lister) listCopilot(projectPath string) ([]SessionInfo, []ListWarning, error) {
 	sessionDir := filepath.Join(l.homeDir, ".copilot", "session-state")
 
 	if _, err := os.Stat(sessionDir); os.IsNotExist(err) {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	entries, err := os.ReadDir(sessionDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read session directory: %w", err)
+		return nil, nil, fmt.Errorf("failed to read session directory: %w", err)
 	}
 
 	var sessions []SessionInfo
+	var warnings []ListWarning
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -262,11 +272,21 @@ func (l *Lister) listCopilot(projectPath string) ([]SessionInfo, error) {
 		}
 
 		ws, err := parseCopilotWorkspace(workspacePath)
-		if err != nil || ws == nil {
-			continue
+		if err != nil {
+			warnings = append(warnings, ListWarning{
+				Source: SourceCopilot,
+				Err:    fmt.Errorf("session %s: %w", entry.Name(), err),
+			})
+			ws = nil
 		}
 
+		// Workspace metadata is only required when filtering by project.
+		// Without metadata we cannot match a project filter, so skip in
+		// that case; otherwise include the session.
 		if projectPath != "" {
+			if ws == nil {
+				continue
+			}
 			matchPath := ws.GitRoot
 			if matchPath == "" {
 				matchPath = ws.Cwd
@@ -277,7 +297,7 @@ func (l *Lister) listCopilot(projectPath string) ([]SessionInfo, error) {
 		}
 
 		var createdAt time.Time
-		if ws.CreatedAt != nil {
+		if ws != nil && ws.CreatedAt != nil {
 			createdAt = *ws.CreatedAt
 		} else {
 			createdAt = eventsInfo.ModTime()
@@ -291,7 +311,7 @@ func (l *Lister) listCopilot(projectPath string) ([]SessionInfo, error) {
 		})
 	}
 
-	return sessions, nil
+	return sessions, warnings, nil
 }
 
 // listKiro returns all Kiro CLI sessions for a project directory.
@@ -455,6 +475,10 @@ type copilotWorkspace struct {
 }
 
 // parseCopilotWorkspace parses a Copilot workspace.yaml file.
+// Returns (nil, nil) when the file does not exist (callers treat the
+// session as having no workspace metadata). Returns a non-nil error when
+// the file exists but cannot be read or parsed, so callers can surface a
+// warning instead of silently dropping the session.
 func parseCopilotWorkspace(path string) (*copilotWorkspace, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -466,7 +490,7 @@ func parseCopilotWorkspace(path string) (*copilotWorkspace, error) {
 
 	var ws copilotWorkspace
 	if err := yaml.Unmarshal(data, &ws); err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("parse workspace.yaml: %w", err)
 	}
 
 	return &ws, nil

--- a/internal/sessions/lister_test.go
+++ b/internal/sessions/lister_test.go
@@ -509,6 +509,152 @@ func TestListAllCopilotSessionsEmptyProjectPath(t *testing.T) {
 	}
 }
 
+// setupCopilotSessionMissingWorkspace creates a Copilot session directory
+// with a non-empty events.jsonl but no workspace.yaml at all.
+func setupCopilotSessionMissingWorkspace(t *testing.T, homeDir, sessionID string, modTime time.Time) {
+	t.Helper()
+	sessionDir := filepath.Join(homeDir, ".copilot", "session-state", sessionID)
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+	eventsPath := filepath.Join(sessionDir, "events.jsonl")
+	if err := os.WriteFile(eventsPath, []byte(`{"type":"event","data":"test"}`+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write events file: %v", err)
+	}
+	if err := os.Chtimes(eventsPath, modTime, modTime); err != nil {
+		t.Fatalf("failed to set events mtime: %v", err)
+	}
+}
+
+// setupCopilotSessionInvalidWorkspace creates a Copilot session directory with
+// a non-empty events.jsonl and a workspace.yaml that fails to parse as YAML.
+func setupCopilotSessionInvalidWorkspace(t *testing.T, homeDir, sessionID string, modTime time.Time) {
+	t.Helper()
+	sessionDir := filepath.Join(homeDir, ".copilot", "session-state", sessionID)
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+	eventsPath := filepath.Join(sessionDir, "events.jsonl")
+	if err := os.WriteFile(eventsPath, []byte(`{"type":"event","data":"test"}`+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write events file: %v", err)
+	}
+	if err := os.Chtimes(eventsPath, modTime, modTime); err != nil {
+		t.Fatalf("failed to set events mtime: %v", err)
+	}
+	// Intentionally malformed YAML — unterminated block, bad indent, control chars.
+	bad := []byte("id: \"unterminated\ncwd: : :\n\t- not yaml\n")
+	if err := os.WriteFile(filepath.Join(sessionDir, "workspace.yaml"), bad, 0644); err != nil {
+		t.Fatalf("failed to write workspace file: %v", err)
+	}
+}
+
+// TestListAllCopilotSessionsMissingWorkspace is a regression test for T-701.
+// Sessions with a valid non-empty events.jsonl but no workspace.yaml at all
+// must be listed when no project filter is applied. Previously listCopilot
+// dropped them silently because parseCopilotWorkspace returned (nil, nil) for
+// missing files and the caller treated ws == nil as "skip".
+func TestListAllCopilotSessionsMissingWorkspace(t *testing.T) {
+	homeDir := t.TempDir()
+
+	sessionID := "missing-workspace-session"
+	modTime := time.Date(2025, 4, 1, 12, 0, 0, 0, time.UTC)
+	setupCopilotSessionMissingWorkspace(t, homeDir, sessionID, modTime)
+
+	lister := newTestLister(homeDir)
+
+	sessions, _, err := lister.ListAll("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var copilotSessions []SessionInfo
+	for _, s := range sessions {
+		if s.Source == SourceCopilot {
+			copilotSessions = append(copilotSessions, s)
+		}
+	}
+
+	if len(copilotSessions) != 1 {
+		t.Fatalf("expected 1 Copilot session with missing workspace.yaml, got %d", len(copilotSessions))
+	}
+	if copilotSessions[0].ID != sessionID {
+		t.Errorf("session.ID = %q, want %q", copilotSessions[0].ID, sessionID)
+	}
+	if !copilotSessions[0].CreatedAt.Equal(modTime) {
+		t.Errorf("CreatedAt = %v, want events mtime %v", copilotSessions[0].CreatedAt, modTime)
+	}
+}
+
+// TestListAllCopilotSessionsInvalidWorkspace is a regression test for T-701.
+// Sessions with a valid non-empty events.jsonl but a workspace.yaml that
+// cannot be parsed must still be listed when no project filter is applied.
+func TestListAllCopilotSessionsInvalidWorkspace(t *testing.T) {
+	homeDir := t.TempDir()
+
+	sessionID := "invalid-workspace-session"
+	modTime := time.Date(2025, 4, 2, 9, 0, 0, 0, time.UTC)
+	setupCopilotSessionInvalidWorkspace(t, homeDir, sessionID, modTime)
+
+	lister := newTestLister(homeDir)
+
+	sessions, _, err := lister.ListAll("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var copilotSessions []SessionInfo
+	for _, s := range sessions {
+		if s.Source == SourceCopilot {
+			copilotSessions = append(copilotSessions, s)
+		}
+	}
+
+	if len(copilotSessions) != 1 {
+		t.Fatalf("expected 1 Copilot session with invalid workspace.yaml, got %d", len(copilotSessions))
+	}
+	if copilotSessions[0].ID != sessionID {
+		t.Errorf("session.ID = %q, want %q", copilotSessions[0].ID, sessionID)
+	}
+}
+
+// TestListCopilotSessionsMalformedWorkspaceWithFilter verifies that when a
+// project filter IS supplied, sessions with missing or invalid workspace.yaml
+// do not falsely match (they have no metadata to compare against). They must
+// be skipped — silently or with a warning, but never matched.
+func TestListCopilotSessionsMalformedWorkspaceWithFilter(t *testing.T) {
+	homeDir := t.TempDir()
+	projectPath := t.TempDir()
+
+	modTime := time.Date(2025, 4, 3, 9, 0, 0, 0, time.UTC)
+	// One session with valid workspace pointing at projectPath — should match.
+	setupCopilotSession(t, homeDir, projectPath, "valid-session", modTime)
+	// One session with no workspace.yaml at all — must NOT match a project filter.
+	setupCopilotSessionMissingWorkspace(t, homeDir, "missing-workspace-session", modTime)
+	// One session with malformed workspace.yaml — must NOT match a project filter.
+	setupCopilotSessionInvalidWorkspace(t, homeDir, "invalid-workspace-session", modTime)
+
+	lister := newTestLister(homeDir)
+
+	sessions, _, err := lister.ListAll(projectPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var copilotSessions []SessionInfo
+	for _, s := range sessions {
+		if s.Source == SourceCopilot {
+			copilotSessions = append(copilotSessions, s)
+		}
+	}
+
+	if len(copilotSessions) != 1 {
+		t.Fatalf("expected 1 Copilot session matching project filter, got %d", len(copilotSessions))
+	}
+	if copilotSessions[0].ID != "valid-session" {
+		t.Errorf("session.ID = %q, want %q", copilotSessions[0].ID, "valid-session")
+	}
+}
+
 // setupCodexSessionWithLeadingLines creates a Codex session file where
 // session_meta is NOT the first line. Non-meta entries appear before it.
 func setupCodexSessionWithLeadingLines(t *testing.T, homeDir, projectPath, sessionID string, createdAt time.Time, leadingLines int) {

--- a/internal/sessions/lister_test.go
+++ b/internal/sessions/lister_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -597,7 +598,7 @@ func TestListAllCopilotSessionsInvalidWorkspace(t *testing.T) {
 
 	lister := newTestLister(homeDir)
 
-	sessions, _, err := lister.ListAll("")
+	sessions, warnings, err := lister.ListAll("")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -614,6 +615,21 @@ func TestListAllCopilotSessionsInvalidWorkspace(t *testing.T) {
 	}
 	if copilotSessions[0].ID != sessionID {
 		t.Errorf("session.ID = %q, want %q", copilotSessions[0].ID, sessionID)
+	}
+
+	// Verify a warning was emitted for the unparseable workspace.yaml so the
+	// listing is observable even though the session is still returned.
+	var copilotWarnings []ListWarning
+	for _, w := range warnings {
+		if w.Source == SourceCopilot {
+			copilotWarnings = append(copilotWarnings, w)
+		}
+	}
+	if len(copilotWarnings) == 0 {
+		t.Fatal("expected a ListWarning for invalid workspace.yaml, got none")
+	}
+	if !strings.Contains(copilotWarnings[0].Err.Error(), sessionID) {
+		t.Errorf("warning %q does not reference session ID %q", copilotWarnings[0].Err.Error(), sessionID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `listCopilot` (apsis -l) and `DiscoverSessions` (Orbit Copilot resume discovery) previously dropped sessions whose `workspace.yaml` was missing or unparseable, even when `events.jsonl` was valid and non-empty.
- After this change, sessions with valid events are listed when no project filter is applied; metadata is only required when filtering by project path.
- YAML parse failures are surfaced as `ListWarning` entries via `ListAll` instead of being silently swallowed.

## Root Cause

Both call sites used `if err != nil || ws == nil { continue }` after `parseCopilotWorkspace`. `parseCopilotWorkspace` returns `(nil, nil)` for a missing file (intentional) and previously also for invalid YAML (silently swallowed). The guard conflated "metadata unavailable" with "not a session", causing valid sessions with missing or corrupt workspace files to be silently dropped from listings and resume discovery.

## Fix

- `internal/sessions/lister.go`: `listCopilot` no longer treats `ws == nil` as "skip"; instead, it skips only when a project filter is set and metadata is unavailable. Surfaces YAML parse errors as `ListWarning`. Returns `([]SessionInfo, []ListWarning, error)`. `parseCopilotWorkspace` now returns the YAML error rather than swallowing it.
- `internal/agents/copilot/agent.go`: `DiscoverSessions` applies the same inclusion logic. `parseCopilotWorkspace` returns the YAML error.
- Updates `docs/agent-notes/apsis-session-listing.md` to describe the new behaviour.

## Regression Tests

Six new tests covering both packages:

- `internal/sessions`: `TestListAllCopilotSessionsMissingWorkspace`, `TestListAllCopilotSessionsInvalidWorkspace`, `TestListCopilotSessionsMalformedWorkspaceWithFilter`.
- `internal/agents/copilot`: `TestDiscoverSessions_MissingWorkspaceYAML`, `TestDiscoverSessions_InvalidWorkspaceYAML`, `TestDiscoverSessions_MalformedWorkspaceWithFilter`.

The first two in each pair fail before the fix and pass after; the third confirms that under a project filter, sessions without usable metadata do not falsely match.

## Test plan

- [x] `go test ./internal/sessions/ ./internal/agents/copilot/ -run "Copilot|DiscoverSessions" -v`
- [x] `make test` (full suite)
- [x] `make lint`
- [ ] Manual: place a Copilot session under `~/.copilot/session-state/<id>/` with valid `events.jsonl` and no `workspace.yaml`; confirm `apsis -l` lists it.

Closes T-701.