### PR TITLE
Fix T-715: Variant Post-Prompt Continues Phase Session

### DIFF
--- a/docs/agent-notes/agent-execution.md
+++ b/docs/agent-notes/agent-execution.md
@@ -79,6 +79,22 @@ Two helper functions in `internal/orbit/single.go`:
 - Long sleeps (rate-limit waits) are broken into 30-second chunks with context checks between them, so Ctrl+C is responsive even during multi-hour usage limit waits.
 - Rate-limit resets are capped at 5 to prevent infinite loops if the condition never resolves.
 
+## Variant Post-Prompt Session Lifecycle (`internal/orbit/variants.go`)
+
+`runVariantPostCompletion` mirrors single-run `runPostPrompt`:
+
+1. `logManager.StartPostCompletion(ContinueSession)` returns `(sessionID, isResume)`.
+2. If `isResume`, call `agent.Resume(sessionID, opts)`. On invalid-session
+   error, fall back to a fresh UUID + `agent.Run`, and update the manager
+   via `SetPostCompletionSessionID`.
+3. On success, reconcile the agent-returned session id via
+   `ReconcilePostCompletionSessionID` and clear the in-progress entry via
+   `CompletePostCompletion`.
+
+Without these calls, variant post-prompt always opens a brand-new session,
+losing phase context and bypassing the documented post-completion lifecycle
+(T-715).
+
 ## Claude Code Usage Limit Parsing (`internal/agents/claudecode/errors.go`)
 
 `parseUsageLimitReset()` extracts the reset time from messages like `"resets 3am (Australia/Melbourne)"` or `"resets 3am"` (no timezone). The timezone in parentheses is optional -- when absent, `time.Local` is used as the default. The regex uses 4 capture groups; `FindStringSubmatch` returns a 5-element slice on match (or nil), so `matches[4]` is `""` when the optional timezone group doesn't match.

--- a/internal/orbit/orbit_test.go
+++ b/internal/orbit/orbit_test.go
@@ -2,6 +2,7 @@ package orbit
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -2000,7 +2001,7 @@ func TestVariantPostCompletion_NilRunResult(t *testing.T) {
 
 	// This should NOT panic. Before the fix, it would panic on nil dereference.
 	// Like runVariantPhaseWithRetry, the default classifier returns non-retryable.
-	_, err := o.runVariantPostCompletion(context.Background(), v, agent, 0)
+	_, err := o.runVariantPostCompletion(context.Background(), v, agent, nil, 0)
 	if err == nil {
 		t.Fatal("expected ClassifiedError, got nil")
 	}
@@ -2170,5 +2171,160 @@ func TestRunVariantsParallel_CancelPreservesMixedStatuses(t *testing.T) {
 		if v.Status != variants.StatusPending {
 			t.Errorf("variant %d: status = %q, want %q", v.ID, v.Status, variants.StatusPending)
 		}
+	}
+}
+
+// TestVariantPostCompletion_ResumesPriorSession is the regression test for T-715.
+//
+// Variant post-prompt should mirror single-run post-prompt session lifecycle: it
+// must coordinate the session through the variant log manager so that when a
+// post-completion is already in progress (interrupted run resumed via
+// ContinueSession), the agent's Resume() path is used instead of starting a
+// brand-new session via Run() with a fresh UUID.
+//
+// Before the fix, runVariantPostCompletion always generated a fresh UUID and
+// invoked agent.Run(), regardless of the log manager state. Resume() was never
+// called for variant post-prompt, diverging from the documented single-run
+// semantics.
+func TestVariantPostCompletion_ResumesPriorSession(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Seed a variant log manager that already has an in-progress post-completion
+	// state recorded — simulating a prior post-prompt run that was interrupted.
+	logManager, err := logs.NewManagerWithOptions(tmpDir, "variant-1", tmpDir, logs.ManagerOptions{UseSubdirs: false})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions: %v", err)
+	}
+	priorSessionID, _, err := logManager.StartPostCompletion(false)
+	if err != nil {
+		t.Fatalf("StartPostCompletion seeding failed: %v", err)
+	}
+
+	// Configure a TestAgent that succeeds on first call. The recorder will let
+	// us assert which method (Run vs Resume) was invoked and with which session.
+	scenario := testutil.NewScenario().
+		Success(priorSessionID, 0.01).
+		Build()
+	agent := testutil.NewTestAgent(t, "test-agent", scenario)
+	t.Cleanup(func() { agent.AssertAllConsumed(t) })
+
+	o := &Orbit{
+		config: Config{
+			PostPrompt:      "review implementation",
+			ContinueSession: true,
+		},
+		debug: debug.New(false, ""),
+	}
+
+	v := &variants.Variant{
+		ID:           1,
+		WorktreePath: tmpDir,
+	}
+
+	// New post-completion call should resume the prior session via Resume().
+	result, runErr := o.runVariantPostCompletion(context.Background(), v, agent, logManager, 0)
+	if runErr != nil {
+		t.Fatalf("runVariantPostCompletion failed: %v", runErr)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	calls := agent.Recorder().Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 agent call, got %d", len(calls))
+	}
+	if calls[0].Method != "Resume" {
+		t.Errorf("expected Resume method to be called, got %q", calls[0].Method)
+	}
+	if calls[0].SessionID != priorSessionID {
+		t.Errorf("Resume session id = %q, want %q", calls[0].SessionID, priorSessionID)
+	}
+
+	// Post-completion state should be cleared after success — verify via the
+	// on-disk summary.json that CompletePostCompletion was called.
+	if pc := readPostCompletion(t, logManager.SessionDir()); pc != nil {
+		t.Errorf("expected post_completion to be cleared after success, still set: %+v", pc)
+	}
+}
+
+// readPostCompletion loads summary.json from sessionDir and returns the
+// post_completion field as a generic map (or nil if absent). Test helper for
+// verifying log-manager state without relying on internal summary access.
+func readPostCompletion(t *testing.T, sessionDir string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(sessionDir, "summary.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read summary.json: %v", err)
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(data, &summary); err != nil {
+		t.Fatalf("unmarshal summary.json: %v", err)
+	}
+	pc, ok := summary["post_completion"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return pc
+}
+
+// TestVariantPostCompletion_FreshSessionTracksLogManager verifies that even when
+// no prior post-completion exists, the log manager is updated with a session ID
+// (so orbit status can show live activity) and the post-completion state is
+// cleared after success. Companion regression for T-715.
+func TestVariantPostCompletion_FreshSessionTracksLogManager(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logManager, err := logs.NewManagerWithOptions(tmpDir, "variant-1", tmpDir, logs.ManagerOptions{UseSubdirs: false})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions: %v", err)
+	}
+
+	// Single Run call — agent returns its own session ID, exercising
+	// ReconcilePostCompletionSessionID.
+	scenario := testutil.NewScenario().
+		Success("agent-returned-session", 0.02).
+		Build()
+	agent := testutil.NewTestAgent(t, "test-agent", scenario)
+	t.Cleanup(func() { agent.AssertAllConsumed(t) })
+
+	o := &Orbit{
+		config: Config{PostPrompt: "review implementation"},
+		debug:  debug.New(false, ""),
+	}
+
+	v := &variants.Variant{
+		ID:           1,
+		WorktreePath: tmpDir,
+	}
+
+	result, runErr := o.runVariantPostCompletion(context.Background(), v, agent, logManager, 0)
+	if runErr != nil {
+		t.Fatalf("runVariantPostCompletion failed: %v", runErr)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	calls := agent.Recorder().Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 agent call, got %d", len(calls))
+	}
+	// Without an in-progress post-completion in the log manager, Run() is the
+	// correct method (nothing to resume). The session ID should be a UUID
+	// generated through StartPostCompletion, not blank.
+	if calls[0].Method != "Run" {
+		t.Errorf("expected Run method, got %q", calls[0].Method)
+	}
+	if calls[0].Options.SessionID == "" {
+		t.Errorf("expected a session id to be passed to Run, got empty string")
+	}
+
+	// After success, post-completion state should be cleared.
+	if pc := readPostCompletion(t, logManager.SessionDir()); pc != nil {
+		t.Errorf("expected post_completion to be cleared after success, still set: %+v", pc)
 	}
 }

--- a/internal/orbit/orbit_test.go
+++ b/internal/orbit/orbit_test.go
@@ -2001,7 +2001,7 @@ func TestVariantPostCompletion_NilRunResult(t *testing.T) {
 
 	// This should NOT panic. Before the fix, it would panic on nil dereference.
 	// Like runVariantPhaseWithRetry, the default classifier returns non-retryable.
-	_, err := o.runVariantPostCompletion(context.Background(), v, agent, nil, 0)
+	_, err := o.runVariantPostCompletion(t.Context(), v, agent, nil, 0)
 	if err == nil {
 		t.Fatal("expected ClassifiedError, got nil")
 	}
@@ -2222,7 +2222,7 @@ func TestVariantPostCompletion_ResumesPriorSession(t *testing.T) {
 	}
 
 	// New post-completion call should resume the prior session via Resume().
-	result, runErr := o.runVariantPostCompletion(context.Background(), v, agent, logManager, 0)
+	result, runErr := o.runVariantPostCompletion(t.Context(), v, agent, logManager, 0)
 	if runErr != nil {
 		t.Fatalf("runVariantPostCompletion failed: %v", runErr)
 	}
@@ -2301,7 +2301,7 @@ func TestVariantPostCompletion_FreshSessionTracksLogManager(t *testing.T) {
 		WorktreePath: tmpDir,
 	}
 
-	result, runErr := o.runVariantPostCompletion(context.Background(), v, agent, logManager, 0)
+	result, runErr := o.runVariantPostCompletion(t.Context(), v, agent, logManager, 0)
 	if runErr != nil {
 		t.Fatalf("runVariantPostCompletion failed: %v", runErr)
 	}
@@ -2324,6 +2324,77 @@ func TestVariantPostCompletion_FreshSessionTracksLogManager(t *testing.T) {
 	}
 
 	// After success, post-completion state should be cleared.
+	if pc := readPostCompletion(t, logManager.SessionDir()); pc != nil {
+		t.Errorf("expected post_completion to be cleared after success, still set: %+v", pc)
+	}
+}
+
+// TestVariantPostCompletion_FallsBackToFreshSessionOnInvalid verifies that when
+// Resume() fails because the prior session is gone (ErrorClassSessionInvalid),
+// runVariantPostCompletion generates a fresh session id, updates the log
+// manager via SetPostCompletionSessionID, and retries with Run() in the same
+// retry iteration. This is the most nuanced part of the T-715 fix.
+func TestVariantPostCompletion_FallsBackToFreshSessionOnInvalid(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	logManager, err := logs.NewManagerWithOptions(tmpDir, "variant-1", tmpDir, logs.ManagerOptions{UseSubdirs: false})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions: %v", err)
+	}
+	priorSessionID, _, err := logManager.StartPostCompletion(false)
+	if err != nil {
+		t.Fatalf("StartPostCompletion seeding failed: %v", err)
+	}
+
+	// Resume hits SessionInvalid; the function should regenerate a session id
+	// and call Run() within the same Execute closure (no retry-loop bounce).
+	scenario := testutil.NewScenario().
+		SessionInvalid().
+		Success("fresh-agent-session", 0.02).
+		Build()
+	agent := testutil.NewTestAgent(t, "test-agent", scenario)
+	t.Cleanup(func() { agent.AssertAllConsumed(t) })
+
+	o := &Orbit{
+		config: Config{
+			PostPrompt:      "review implementation",
+			ContinueSession: true,
+		},
+		debug: debug.New(false, ""),
+	}
+
+	v := &variants.Variant{
+		ID:           1,
+		WorktreePath: tmpDir,
+	}
+
+	result, runErr := o.runVariantPostCompletion(t.Context(), v, agent, logManager, 0)
+	if runErr != nil {
+		t.Fatalf("runVariantPostCompletion failed: %v", runErr)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	calls := agent.Recorder().Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 agent calls (Resume + Run fallback), got %d", len(calls))
+	}
+	if calls[0].Method != "Resume" {
+		t.Errorf("call 0: expected Resume, got %q", calls[0].Method)
+	}
+	if calls[0].SessionID != priorSessionID {
+		t.Errorf("call 0: Resume session id = %q, want %q", calls[0].SessionID, priorSessionID)
+	}
+	if calls[1].Method != "Run" {
+		t.Errorf("call 1: expected Run, got %q", calls[1].Method)
+	}
+	if calls[1].Options.SessionID == "" || calls[1].Options.SessionID == priorSessionID {
+		t.Errorf("call 1: Run should use a fresh session id, got %q (prior was %q)",
+			calls[1].Options.SessionID, priorSessionID)
+	}
+
+	// State should be cleared after the successful fallback Run().
 	if pc := readPostCompletion(t, logManager.SessionDir()); pc != nil {
 		t.Errorf("expected post_completion to be cleared after success, still set: %+v", pc)
 	}

--- a/internal/orbit/orbit_test.go
+++ b/internal/orbit/orbit_test.go
@@ -2407,8 +2407,9 @@ func TestVariantPostCompletion_FallsBackToFreshSessionOnInvalid(t *testing.T) {
 // the original (likely dead) session id rather than the one the agent
 // actually ended up using.
 func TestVariantPostCompletion_ReconcilesSessionIDOnRetryableError(t *testing.T) {
-	// Force the claude-code classifier so a retryable error is classified as
-	// ErrorClassRetryable (the default classifier marks everything fatal).
+	// Touch the registry so the claudecode init() side effect is in scope —
+	// classifyFromAgent("claude-code") then returns the retryable classifier
+	// instead of the default (which would mark every error fatal).
 	_ = agents.GetClassifier("claude-code")
 
 	clock := testutil.NewFakeClock(time.Now())

--- a/internal/orbit/orbit_test.go
+++ b/internal/orbit/orbit_test.go
@@ -2399,3 +2399,85 @@ func TestVariantPostCompletion_FallsBackToFreshSessionOnInvalid(t *testing.T) {
 		t.Errorf("expected post_completion to be cleared after success, still set: %+v", pc)
 	}
 }
+
+// TestVariantPostCompletion_ReconcilesSessionIDOnRetryableError verifies that
+// when the agent returns a retryable error with a session id different from
+// the one we asked for, runVariantPostCompletion still calls
+// ReconcilePostCompletionSessionID. Without that, the next retry would resume
+// the original (likely dead) session id rather than the one the agent
+// actually ended up using.
+func TestVariantPostCompletion_ReconcilesSessionIDOnRetryableError(t *testing.T) {
+	// Force the claude-code classifier so a retryable error is classified as
+	// ErrorClassRetryable (the default classifier marks everything fatal).
+	_ = agents.GetClassifier("claude-code")
+
+	clock := testutil.NewFakeClock(time.Now())
+
+	tmpDir := t.TempDir()
+	logManager, err := logs.NewManagerWithOptions(tmpDir, "variant-1", tmpDir, logs.ManagerOptions{UseSubdirs: false})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions: %v", err)
+	}
+
+	// First call: retryable error but result reports a different agent session
+	// id (the reconcile path should pick this up). Second call: success on
+	// the reconciled id. Custom is used so we can attach a SessionID to the
+	// retryable error result, which the canned RetryableError builder omits.
+	const reconciledID = "agent-reported-id"
+	scenario := testutil.NewScenario().
+		Custom(func(_ *testutil.AgentCall) *testutil.CallResponse {
+			return &testutil.CallResponse{
+				Result: &agents.RunResult{
+					SessionID: reconciledID,
+					ExitCode:  1,
+					IsError:   true,
+					Stderr:    "connection timeout",
+					Errors:    []string{"connection timeout"},
+				},
+				ErrorClass: agents.ErrorClassRetryable,
+			}
+		}).
+		Success(reconciledID, 0.01).
+		Build()
+
+	agent := testutil.NewTestAgent(t, "claude-code", scenario, testutil.WithClock(clock))
+	t.Cleanup(func() { agent.AssertAllConsumed(t) })
+
+	o := &Orbit{
+		config: Config{
+			PostPrompt:      "review implementation",
+			ContinueSession: true,
+			Clock:           clock,
+		},
+		debug: debug.New(false, ""),
+	}
+
+	v := &variants.Variant{
+		ID:           1,
+		WorktreePath: tmpDir,
+	}
+
+	result, runErr := o.runVariantPostCompletion(t.Context(), v, agent, logManager, 0)
+	if runErr != nil {
+		t.Fatalf("runVariantPostCompletion failed: %v", runErr)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	calls := agent.Recorder().Calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 agent calls, got %d", len(calls))
+	}
+
+	// On the second attempt, StartPostCompletion must have surfaced the
+	// reconciled id so Resume targets the right session — proving reconcile
+	// happened despite the first call returning IsError=true.
+	if calls[1].Method != "Resume" {
+		t.Errorf("call 1: expected Resume after retry, got %q", calls[1].Method)
+	}
+	if calls[1].SessionID != reconciledID {
+		t.Errorf("call 1: expected reconciled session id %q, got %q",
+			reconciledID, calls[1].SessionID)
+	}
+}

--- a/internal/orbit/variants.go
+++ b/internal/orbit/variants.go
@@ -915,6 +915,7 @@ func (o *Orbit) runVariantPostCompletion(
 				var err error
 				sessionID, isResume, err = logManager.StartPostCompletion(o.config.ContinueSession)
 				if err != nil {
+					log.Printf("Warning: variant %d failed to start post-completion in log manager: %v", v.ID, err)
 					o.debug.Log("Variant %d: failed to start post-completion in log manager: %v", v.ID, err)
 					sessionID = uuid.NewString()
 					isResume = false

--- a/internal/orbit/variants.go
+++ b/internal/orbit/variants.go
@@ -956,14 +956,20 @@ func (o *Orbit) runVariantPostCompletion(
 				result, err = agent.Run(ctx, opts)
 			}
 
+			// Reconcile the agent-returned session id even when the call
+			// failed: a retry needs StartPostCompletion to surface the most
+			// recent id, otherwise we resume into an already-dead session.
+			// Guard against empty SessionID so we don't overwrite the stored
+			// id with "" when the agent omits it.
+			if logManager != nil && result != nil && result.SessionID != "" && result.SessionID != sessionID {
+				o.debug.Log("Variant %d: post-completion session id changed: expected=%s got=%s",
+					v.ID, sessionID, result.SessionID)
+				logManager.ReconcilePostCompletionSessionID(result.SessionID)
+			}
+
+			// Only clear in-progress state on a clean success — a retryable
+			// failure must keep the entry so the next attempt can resume it.
 			if err == nil && result != nil && !result.IsError && logManager != nil {
-				// Guard against empty SessionID so we don't overwrite the
-				// stored id with "" when the agent omits it on success.
-				if result.SessionID != "" && result.SessionID != sessionID {
-					o.debug.Log("Variant %d: post-completion session id changed: expected=%s got=%s",
-						v.ID, sessionID, result.SessionID)
-					logManager.ReconcilePostCompletionSessionID(result.SessionID)
-				}
 				if completeErr := logManager.CompletePostCompletion(); completeErr != nil {
 					o.debug.Log("Variant %d: failed to complete post-completion in log manager: %v", v.ID, completeErr)
 				}

--- a/internal/orbit/variants.go
+++ b/internal/orbit/variants.go
@@ -893,18 +893,11 @@ func (o *Orbit) runVariantPhaseWithRetry(ctx context.Context, v *variants.Varian
 
 // runVariantPostCompletion executes the post-completion command for a variant.
 //
-// Mirrors single-run runPostPrompt session lifecycle:
-//  1. StartPostCompletion on the variant log manager — if an entry is already
-//     in progress and ContinueSession is set, resume that session via Resume().
-//  2. On invalid-session errors during resume, fall back to a fresh Run() and
-//     update the log manager via SetPostCompletionSessionID.
-//  3. Reconcile the agent-returned session id with the log manager when it
-//     differs from the one we asked for.
-//  4. Clear the in-progress entry on success via CompletePostCompletion.
-//
-// Without this coordination, variant post-prompt loses phase context across
-// resumed runs and silently bypasses the documented post-completion
-// lifecycle (T-715).
+// Coordinates the variant log manager so post-prompt mirrors the single-run
+// lifecycle (StartPostCompletion → Resume/Run → ReconcilePostCompletionSessionID
+// → CompletePostCompletion). Without this coordination, variant post-prompt
+// loses phase context across resumed runs and silently bypasses the
+// post-completion lifecycle (T-715).
 func (o *Orbit) runVariantPostCompletion(
 	ctx context.Context,
 	v *variants.Variant,
@@ -916,7 +909,6 @@ func (o *Orbit) runVariantPostCompletion(
 		MaxRetries: maxRetries,
 		Sleep:      o.sleepFunc(),
 		Execute: func(ctx context.Context, _ int) (*agents.RunResult, error) {
-			// Determine session id and whether to resume from log manager state.
 			var sessionID string
 			var isResume bool
 			if logManager != nil {
@@ -945,7 +937,9 @@ func (o *Orbit) runVariantPostCompletion(
 			var err error
 			if isResume {
 				result, err = agent.Resume(ctx, sessionID, opts)
-				// Fall back to fresh session on invalid-session errors.
+				// Fall back to a fresh session when the agent reports the
+				// resumed session is gone — otherwise the retry loop would
+				// keep hitting the same dead session.
 				if err != nil && isSessionInvalidError(result) {
 					o.debug.Log("Variant %d: post-completion resume failed, starting fresh session", v.ID)
 					log.Printf("Variant %d: post-completion session resume failed, starting fresh session", v.ID)
@@ -962,8 +956,9 @@ func (o *Orbit) runVariantPostCompletion(
 				result, err = agent.Run(ctx, opts)
 			}
 
-			// On success, reconcile the returned session id and clear in-progress state.
 			if err == nil && result != nil && !result.IsError && logManager != nil {
+				// Guard against empty SessionID so we don't overwrite the
+				// stored id with "" when the agent omits it on success.
 				if result.SessionID != "" && result.SessionID != sessionID {
 					o.debug.Log("Variant %d: post-completion session id changed: expected=%s got=%s",
 						v.ID, sessionID, result.SessionID)

--- a/internal/orbit/variants.go
+++ b/internal/orbit/variants.go
@@ -727,7 +727,7 @@ func (o *Orbit) runVariant(ctx context.Context, v *variants.Variant) error {
 	if o.config.PostPrompt != "" {
 		log.Printf("Variant %d: running post-prompt...", v.ID)
 		postStartTime := time.Now()
-		postResult, err := o.runVariantPostCompletion(ctx, v, variantAgent, variantAgentConfig.Timeout)
+		postResult, err := o.runVariantPostCompletion(ctx, v, variantAgent, variantLogManager, variantAgentConfig.Timeout)
 		if err != nil {
 			// Save failed post-prompt session for debugging
 			if variantLogManager != nil && postResult != nil {
@@ -892,18 +892,89 @@ func (o *Orbit) runVariantPhaseWithRetry(ctx context.Context, v *variants.Varian
 }
 
 // runVariantPostCompletion executes the post-completion command for a variant.
-func (o *Orbit) runVariantPostCompletion(ctx context.Context, v *variants.Variant, agent agents.Agent, timeout time.Duration) (*agents.RunResult, error) {
+//
+// Mirrors single-run runPostPrompt session lifecycle:
+//  1. StartPostCompletion on the variant log manager — if an entry is already
+//     in progress and ContinueSession is set, resume that session via Resume().
+//  2. On invalid-session errors during resume, fall back to a fresh Run() and
+//     update the log manager via SetPostCompletionSessionID.
+//  3. Reconcile the agent-returned session id with the log manager when it
+//     differs from the one we asked for.
+//  4. Clear the in-progress entry on success via CompletePostCompletion.
+//
+// Without this coordination, variant post-prompt loses phase context across
+// resumed runs and silently bypasses the documented post-completion
+// lifecycle (T-715).
+func (o *Orbit) runVariantPostCompletion(
+	ctx context.Context,
+	v *variants.Variant,
+	agent agents.Agent,
+	logManager *logs.Manager,
+	timeout time.Duration,
+) (*agents.RunResult, error) {
 	return agents.RunWithRetry(ctx, agents.RetryConfig{
 		MaxRetries: maxRetries,
 		Sleep:      o.sleepFunc(),
 		Execute: func(ctx context.Context, _ int) (*agents.RunResult, error) {
+			// Determine session id and whether to resume from log manager state.
+			var sessionID string
+			var isResume bool
+			if logManager != nil {
+				var err error
+				sessionID, isResume, err = logManager.StartPostCompletion(o.config.ContinueSession)
+				if err != nil {
+					o.debug.Log("Variant %d: failed to start post-completion in log manager: %v", v.ID, err)
+					sessionID = uuid.NewString()
+					isResume = false
+				} else {
+					o.debug.Log("Variant %d: post-completion session %s (resume=%v)", v.ID, sessionID, isResume)
+				}
+			} else {
+				sessionID = uuid.NewString()
+				isResume = false
+			}
+
 			opts := agents.RunOptions{
 				Prompt:    o.config.PostPrompt,
-				SessionID: uuid.NewString(),
+				SessionID: sessionID,
 				WorkDir:   v.WorktreePath,
 				Timeout:   timeout,
 			}
-			return agent.Run(ctx, opts)
+
+			var result *agents.RunResult
+			var err error
+			if isResume {
+				result, err = agent.Resume(ctx, sessionID, opts)
+				// Fall back to fresh session on invalid-session errors.
+				if err != nil && isSessionInvalidError(result) {
+					o.debug.Log("Variant %d: post-completion resume failed, starting fresh session", v.ID)
+					log.Printf("Variant %d: post-completion session resume failed, starting fresh session", v.ID)
+					sessionID = uuid.NewString()
+					if logManager != nil {
+						if setErr := logManager.SetPostCompletionSessionID(sessionID); setErr != nil {
+							o.debug.Log("Variant %d: failed to update post-completion session id: %v", v.ID, setErr)
+						}
+					}
+					opts.SessionID = sessionID
+					result, err = agent.Run(ctx, opts)
+				}
+			} else {
+				result, err = agent.Run(ctx, opts)
+			}
+
+			// On success, reconcile the returned session id and clear in-progress state.
+			if err == nil && result != nil && !result.IsError && logManager != nil {
+				if result.SessionID != "" && result.SessionID != sessionID {
+					o.debug.Log("Variant %d: post-completion session id changed: expected=%s got=%s",
+						v.ID, sessionID, result.SessionID)
+					logManager.ReconcilePostCompletionSessionID(result.SessionID)
+				}
+				if completeErr := logManager.CompletePostCompletion(); completeErr != nil {
+					o.debug.Log("Variant %d: failed to complete post-completion in log manager: %v", v.ID, completeErr)
+				}
+			}
+
+			return result, err
 		},
 		Classify: classifyFromAgent(agent.Name()),
 		OnRetry: func(attempt, maxRetries int, classified *agents.ClassifiedError, backoff time.Duration) {


### PR DESCRIPTION
## Summary
- `internal/orbit/variants.go::runVariantPostCompletion()` was generating a fresh UUID and calling `agent.Run()` every time, bypassing the variant log manager's post-completion lifecycle.
- Mirror single-run `runPostPrompt`: call `StartPostCompletion(ContinueSession)`, use `agent.Resume()` when an in-progress entry exists, fall back to a fresh `Run()` on invalid-session errors (and update the manager via `SetPostCompletionSessionID`), reconcile via `ReconcilePostCompletionSessionID`, and clear via `CompletePostCompletion`.
- Two regression tests in `internal/orbit/orbit_test.go` plus an `agent-execution.md` note describing the lifecycle.

## Root cause
`runVariantPostCompletion` was a thin retry wrapper that never consulted the variant log manager. Variants therefore lost phase-session continuity on resumed runs and silently bypassed the post-completion lifecycle.

## Resolution
Pass `variantLogManager` into `runVariantPostCompletion` and follow the documented session lifecycle. Call site updated at `internal/orbit/variants.go:730`.

## Test plan
- [x] `go test ./internal/orbit -run "TestVariantPostCompletion_(ResumesPriorSession|FreshSessionTracksLogManager|NilRunResult)" -v`
- [x] `make test`
- [x] `make lint`
- [x] `make build`