### PR TITLE
Fix T-683: Honor Shutdown Cancellation In Orbit Compare Diff Gathering

### DIFF
--- a/cmd/orbit/compare.go
+++ b/cmd/orbit/compare.go
@@ -5,8 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/arjenschwarz/orbit/internal/agents"
@@ -20,7 +22,20 @@ import (
 
 // compareCommand executes the orbit compare subcommand.
 // It regenerates the comparison report for existing variant worktrees.
+//
+// The function installs a SIGINT/SIGTERM-aware context so a Ctrl+C while
+// gathering diffs or running the comparison agent stops the work promptly
+// instead of blocking on long-running git or agent calls.
 func compareCommand(args []string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	return runCompare(ctx, args)
+}
+
+// runCompare implements the orbit compare subcommand using the provided context.
+// Extracted from compareCommand so tests can drive it with a controlled context
+// (e.g., to verify cancellation is honored before any git or agent work runs).
+func runCompare(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("compare", flag.ExitOnError)
 
 	compareCmd := fs.String("compare-command", "", "Custom comparison command (not yet supported)")
@@ -110,8 +125,14 @@ func compareCommand(args []string) error {
 
 	fmt.Printf("Comparing %d variants for spec: %s\n\n", len(completedVariants), specName)
 
-	// Collect all variant data (diffs + summaries)
-	ctx := context.Background()
+	// Honor cancellation before doing any work.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Collect all variant data (diffs + summaries) using the cancellable context
+	// so a SIGINT during git diff collection stops promptly instead of blocking
+	// until completion (T-683).
 	fmt.Println("\n  Gathering variant data...")
 	diffGatherer := comparison.NewDiffGatherer(git)
 	variantData, err := diffGatherer.GatherAll(ctx, metadata.BaseCommit, completedVariants)

--- a/cmd/orbit/compare_test.go
+++ b/cmd/orbit/compare_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arjenschwarz/orbit/internal/variants"
+)
+
+// TestRunCompare_HonorsCancelledContext is a regression test for T-683.
+//
+// Bug: orbit compare ignored shutdown cancellation. The subcommand built
+// its diff-gathering and agent contexts from context.Background(), so a
+// SIGINT (Ctrl+C) during long-running git diff collection or agent calls
+// could not stop the work — orbit compare would appear hung.
+//
+// Fix: compareCommand now installs a signal-aware context (SIGINT/SIGTERM)
+// that propagates into GatherAll and the comparison agent. This test drives
+// the extracted runCompare helper with a pre-cancelled context and verifies
+// the function returns context.Canceled before doing any heavy work.
+func TestRunCompare_HonorsCancelledContext(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWd)
+	})
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+
+	// Initialise a git repo so getRepoRoot succeeds.
+	runCmd(t, tmpDir, "git", "init")
+	runCmd(t, tmpDir, "git", "config", "user.email", "test@example.com")
+	runCmd(t, tmpDir, "git", "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("# Test"), 0o644); err != nil {
+		t.Fatalf("failed to write README: %v", err)
+	}
+	runCmd(t, tmpDir, "git", "add", "README.md")
+	runCmd(t, tmpDir, "git", "commit", "-m", "Initial commit")
+
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = tmpDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	baseCommit := strings.TrimSpace(string(out))
+
+	// Build a minimal variants.json with two completed variants. We do not
+	// need real worktrees because the function should return before touching
+	// the git CLI.
+	specName := "test-feature"
+	specOrbitDir := filepath.Join(tmpDir, "specs", specName, ".orbit")
+	if err := os.MkdirAll(specOrbitDir, 0o755); err != nil {
+		t.Fatalf("failed to create spec .orbit dir: %v", err)
+	}
+
+	metadata := variants.VariantsMetadata{
+		RunID:          "test-run-cancel",
+		BaseCommit:     baseCommit,
+		OriginalBranch: "main",
+		StartedAt:      time.Now(),
+		Variants: []*variants.Variant{
+			{
+				ID:           1,
+				Branch:       "orbit-impl-1-test-feature",
+				WorktreePath: filepath.Join(tmpDir, "wt1"),
+				Status:       variants.StatusCompleted,
+			},
+			{
+				ID:           2,
+				Branch:       "orbit-impl-2-test-feature",
+				WorktreePath: filepath.Join(tmpDir, "wt2"),
+				Status:       variants.StatusCompleted,
+			},
+		},
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(specOrbitDir, "variants.json"), data, 0o644); err != nil {
+		t.Fatalf("write variants.json: %v", err)
+	}
+
+	// Provide a .orbit.yaml so RequireConfigFile passes if we ever reach the
+	// agent path. With a cancelled context we should not get there, but the
+	// file makes the test robust to other early-validation paths.
+	if err := os.WriteFile(filepath.Join(tmpDir, ".orbit.yaml"), []byte("agent: claude-code\n"), 0o644); err != nil {
+		t.Fatalf("write .orbit.yaml: %v", err)
+	}
+
+	// Cancel the context before invoking runCompare. The function must
+	// observe cancellation and bail out before doing diff or agent work.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Use --from-file pointing at a non-existent path so that even if the
+	// guard was missing, we would not actually invoke the agent. The
+	// regression we are guarding against is *no early exit at all* — pre-fix
+	// the function would happily call GatherAll with a Background context.
+	err = runCompare(ctx, []string{specName})
+	if err == nil {
+		t.Fatal("expected error from runCompare with cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected error wrapping context.Canceled, got: %v", err)
+	}
+
+	// Report directory must NOT have been created. If it was, that means the
+	// function progressed past the cancellation guard and into report work.
+	reportDir := filepath.Join(tmpDir, "specs", specName, "comparison-report")
+	if _, statErr := os.Stat(reportDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("comparison-report directory should not exist after cancellation; stat err: %v", statErr)
+	}
+}
+
+// runCmd is a small test helper that runs a command in a directory and
+// fails the test if it exits non-zero.
+func runCmd(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
+	}
+}


### PR DESCRIPTION
## Summary

- `orbit compare` ignored shutdown signals during diff gathering and the comparison agent run because it built its working context from `context.Background()`. Ctrl+C did not stop the work, so the command appeared hung on large repos.
- `compareCommand` now installs `signal.NotifyContext(os.Interrupt, syscall.SIGTERM)` and delegates to a new `runCompare(ctx, args)` helper. The helper uses that context for `DiffGatherer.GatherAll` and as the parent of the `CompareUnified` timeout context, and adds an explicit `ctx.Err()` guard before the gathering loop.
- The previous T-586 fix only covered the in-process `orbit run --variants` flow (routed through `Orbit.New`, which already installs the signal context). T-683 extends the fix to the standalone `orbit compare` subcommand path.

## Investigation Notes

- Traced the original ticket text ("`internal/orbit/comparison.go` ... line 244 ... `context.Background()`") to a pre-T-586 view of the code. T-586 already fixed that file. The same class of bug was still live in `cmd/orbit/compare.go:114`, which is what this PR addresses.
- `DiffGatherer.GatherAll`, `GatherDiffs`, and `GatherSummaries` already honor context cancellation per loop iteration — the only missing piece was a cancellable context at the call site.
- Other CLI subcommands (`cleanup`, `consolidate`, `finalize`, `status`) share the same `context.Background()` pattern. Out of scope for T-683 but worth a follow-up.

## Test Plan

- [x] `go test ./cmd/orbit/ -run TestRunCompare_HonorsCancelledContext` (new regression test)
- [x] `make test`
- [x] `make lint`
- [ ] Manual: run `orbit compare <spec>` against a large variant set, press Ctrl+C during "Gathering variant data..." — process should exit promptly with a context-canceled error.

## Regression Coverage

`TestRunCompare_HonorsCancelledContext` drives `runCompare` with a pre-cancelled context and verifies:
- The error returned is `context.Canceled` (via `errors.Is`).
- No `comparison-report` directory is created.

Verified the test fails when `runCompare` is reverted to use `context.Background()` (error becomes "failed to gather variant data: get diff from..."), confirming it catches the regression.