### PR TITLE
Fix T-739: Codex DiscoverSessions ignores projectDir filter

### DIFF
--- a/internal/agents/codex/agent.go
+++ b/internal/agents/codex/agent.go
@@ -2,8 +2,10 @@
 package codex
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -13,6 +15,9 @@ import (
 
 	"github.com/arjenschwarz/orbit/internal/agents"
 )
+
+// codexMetaScanLimit is the maximum number of lines to scan for session_meta.
+const codexMetaScanLimit = 20
 
 // Compile-time interface check.
 var _ agents.Agent = (*Agent)(nil)
@@ -114,6 +119,14 @@ func (a *Agent) DiscoverSessions(ctx context.Context, projectDir string) ([]agen
 			return nil
 		}
 
+		// Filter by projectDir when specified.
+		if projectDir != "" {
+			cwd := codexSessionCwd(path)
+			if cwd == "" || normalizePath(cwd) != normalizePath(projectDir) {
+				return nil
+			}
+		}
+
 		// Strip .jsonl extension and extract UUID if present, consistent with sessions/lister.go.
 		filename := d.Name()
 		sessionID := strings.TrimSuffix(filename, ".jsonl")
@@ -135,6 +148,43 @@ func (a *Agent) DiscoverSessions(ctx context.Context, projectDir string) ([]agen
 	}
 
 	return sessions, nil
+}
+
+// codexSessionCwd extracts the cwd from the session_meta entry of a Codex session file.
+func codexSessionCwd(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for i := 0; i < codexMetaScanLimit && scanner.Scan(); i++ {
+		var entry struct {
+			Type    string          `json:"type"`
+			Payload json.RawMessage `json:"payload"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err == nil {
+			if entry.Type == "session_meta" && len(entry.Payload) > 0 {
+				var meta struct {
+					Cwd string `json:"cwd"`
+				}
+				if err := json.Unmarshal(entry.Payload, &meta); err == nil {
+					return meta.Cwd
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// normalizePath resolves symlinks and cleans a path for reliable comparison.
+func normalizePath(p string) string {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	return filepath.Clean(resolved)
 }
 
 // Run executes a prompt in a new session.

--- a/internal/agents/codex/agent_test.go
+++ b/internal/agents/codex/agent_test.go
@@ -534,3 +534,65 @@ func TestAgent_ArgOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestAgent_DiscoverSessions_FiltersByProjectDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	nestedDir := filepath.Join(tmpDir, "2025", "01", "15")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("failed to create nested dir: %v", err)
+	}
+
+	projectA := filepath.Join(tmpDir, "project-a")
+	projectB := filepath.Join(tmpDir, "project-b")
+	if err := os.MkdirAll(projectA, 0o755); err != nil {
+		t.Fatalf("failed to create project-a: %v", err)
+	}
+	if err := os.MkdirAll(projectB, 0o755); err != nil {
+		t.Fatalf("failed to create project-b: %v", err)
+	}
+
+	// Session belonging to project-a
+	metaA := `{"type":"session_meta","payload":{"cwd":"` + projectA + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(nestedDir, "session-aaa.jsonl"), []byte(metaA), 0o644); err != nil {
+		t.Fatalf("failed to write session file: %v", err)
+	}
+
+	// Session belonging to project-b
+	metaB := `{"type":"session_meta","payload":{"cwd":"` + projectB + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(nestedDir, "session-bbb.jsonl"), []byte(metaB), 0o644); err != nil {
+		t.Fatalf("failed to write session file: %v", err)
+	}
+
+	// Session with no cwd metadata
+	if err := os.WriteFile(filepath.Join(nestedDir, "session-ccc.jsonl"), []byte(`{"type":"session_meta"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write session file: %v", err)
+	}
+
+	agent := &Agent{
+		config:     agents.AgentConfig{},
+		cliPath:    "codex",
+		sessionDir: tmpDir,
+	}
+
+	// Filter by project-a: should return only session-aaa
+	sessions, err := agent.DiscoverSessions(context.Background(), projectA)
+	if err != nil {
+		t.Fatalf("DiscoverSessions() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session for project-a, got %d", len(sessions))
+	}
+	if sessions[0].ID != "session-aaa" {
+		t.Errorf("session.ID = %q, want %q", sessions[0].ID, "session-aaa")
+	}
+
+	// Empty projectDir: should return all sessions
+	all, err := agent.DiscoverSessions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("DiscoverSessions() error = %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 sessions with empty filter, got %d", len(all))
+	}
+}


### PR DESCRIPTION
Adds projectDir filtering to the Codex agent's DiscoverSessions method.

**Changes:**
- internal/agents/codex/agent.go: Added filtering logic with codexSessionCwd helper
- internal/agents/codex/agent_test.go: Added TestAgent_DiscoverSessions_FiltersByProjectDir

Fixes T-739