### PR TITLE
Fix T-765: ParseRetryAfter misses numeric values

### DIFF
--- a/internal/agents/errors.go
+++ b/internal/agents/errors.go
@@ -258,6 +258,7 @@ func BackoffDuration(attempt int) time.Duration {
 // retryAfterPatterns are pre-compiled regexes for extracting retry-after durations.
 var retryAfterPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`retry.?after[:\s]+(\d+)\s*s`),
+	regexp.MustCompile(`retry.?after[:\s]+(\d+)`),
 	regexp.MustCompile(`wait[:\s]+(\d+)\s*s`),
 	regexp.MustCompile(`(\d+)\s*seconds?`),
 }

--- a/internal/agents/errors_test.go
+++ b/internal/agents/errors_test.go
@@ -298,6 +298,8 @@ func TestParseRetryAfter(t *testing.T) {
 	}{
 		{"retry after seconds", "retry after 45 seconds", 45 * time.Second},
 		{"retry-after colon", "retry-after: 30s", 30 * time.Second},
+		{"retry-after numeric only", "retry-after: 120", 120 * time.Second},
+		{"retry after numeric no unit", "retry after 90", 90 * time.Second},
 		{"wait seconds", "wait: 60 seconds", 60 * time.Second},
 		{"default when no match", "rate limit exceeded", DefaultRateLimitRetryAfter},
 	}


### PR DESCRIPTION
Adds support for standard numeric Retry-After header values (seconds without unit suffix).

**Changes:**
- internal/agents/errors.go: Added numeric-only regex pattern
- internal/agents/errors_test.go: Added test cases

Fixes T-765