### PR TITLE
Fix T-821: Variant setup failure leaves branches behind

### DIFF
--- a/internal/variants/manager.go
+++ b/internal/variants/manager.go
@@ -255,6 +255,7 @@ func (m *Manager) Setup(ctx context.Context, continueExisting bool) error {
 	// Create branches and worktrees for each variant that doesn't already exist
 	sanitizedSpec := sanitizeSpecName(m.specName)
 	var createdWorktrees []string
+	var createdBranches []string
 
 	for i := 1; i <= m.config.Count; i++ {
 		// Skip variants that are already completed
@@ -268,16 +269,17 @@ func (m *Manager) Setup(ctx context.Context, continueExisting bool) error {
 		// Create branch at the captured head commit so all variants share the
 		// same base, even if HEAD advances between iterations.
 		if err := m.git.CreateBranch(branchName, headCommit); err != nil {
-			// Cleanup already created worktrees on failure
-			m.cleanupCreated(ctx, createdWorktrees)
+			// Cleanup already created worktrees and branches on failure
+			m.cleanupCreated(ctx, createdWorktrees, createdBranches)
 			return fmt.Errorf("create branch for variant %d: %w", i, err)
 		}
 
+		createdBranches = append(createdBranches, branchName)
+
 		// Create worktree
 		if err := m.git.CreateWorktree(ctx, worktreePath, branchName); err != nil {
-			// Cleanup already created worktrees and this branch
-			_ = m.git.DeleteBranch(branchName)
-			m.cleanupCreated(ctx, createdWorktrees)
+			// Cleanup already created worktrees and branches (includes this branch)
+			m.cleanupCreated(ctx, createdWorktrees, createdBranches)
 			return fmt.Errorf("create worktree for variant %d: %w", i, err)
 		}
 
@@ -304,17 +306,20 @@ func (m *Manager) Setup(ctx context.Context, continueExisting bool) error {
 	m.mu.Unlock()
 
 	if err != nil {
-		m.cleanupCreated(ctx, createdWorktrees)
+		m.cleanupCreated(ctx, createdWorktrees, createdBranches)
 		return fmt.Errorf("save metadata: %w", err)
 	}
 
 	return nil
 }
 
-// cleanupCreated removes worktrees that were created during a failed setup.
-func (m *Manager) cleanupCreated(ctx context.Context, paths []string) {
+// cleanupCreated removes worktrees and branches that were created during a failed setup.
+func (m *Manager) cleanupCreated(ctx context.Context, paths []string, branches []string) {
 	for _, path := range paths {
 		_ = m.git.RemoveWorktree(ctx, path)
+	}
+	for _, branch := range branches {
+		_ = m.git.DeleteBranch(branch)
 	}
 }
 

--- a/internal/variants/manager_test.go
+++ b/internal/variants/manager_test.go
@@ -3,6 +3,7 @@ package variants
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -1544,6 +1545,113 @@ func TestSetup_NewRunNoCompletedVariantsAllowsDifferentHEAD(t *testing.T) {
 	if mgr.metadata.BaseCommit != "abc123def456" {
 		t.Errorf("BaseCommit should be current HEAD 'abc123def456', got %q", mgr.metadata.BaseCommit)
 	}
+}
+
+// TestSetup_CleansUpBranchesOnPartialFailure is the regression test for T-821.
+// When variant setup fails partway through (e.g., 3rd branch creation fails),
+// branches that were already created must be cleaned up to avoid orphaned branches.
+func TestSetup_CleansUpBranchesOnPartialFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, "specs", "test-spec")
+
+	// Use a mock that fails on the 3rd CreateBranch call
+	git := &failOnNthBranchMock{
+		mockGitClient: newMockGitClient(),
+		failOnCall:    3,
+	}
+
+	cfg := Config{Count: 3, BranchPrefix: "orbit-impl"}
+	mgr, err := NewManager(cfg, "test-spec", specDir, tmpDir, git)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	ctx := context.Background()
+	err = mgr.Setup(ctx, false)
+	if err == nil {
+		t.Fatal("expected error from Setup")
+	}
+
+	// Branches 1 and 2 were created successfully before branch 3 failed.
+	// They must be deleted during cleanup.
+	if len(git.mockGitClient.deletedBranches) != 2 {
+		t.Errorf("expected 2 deleted branches, got %d: %v",
+			len(git.mockGitClient.deletedBranches), git.mockGitClient.deletedBranches)
+	}
+
+	// Worktrees 1 and 2 were also created and must be removed.
+	if len(git.mockGitClient.removedWorktrees) != 2 {
+		t.Errorf("expected 2 removed worktrees, got %d: %v",
+			len(git.mockGitClient.removedWorktrees), git.mockGitClient.removedWorktrees)
+	}
+}
+
+// TestSetup_CleansUpBranchesOnWorktreeFailure verifies that when worktree creation
+// fails, the branch for that worktree AND all previously created branches are cleaned up.
+func TestSetup_CleansUpBranchesOnWorktreeFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	specDir := filepath.Join(tmpDir, "specs", "test-spec")
+
+	// Use a mock that fails on the 2nd CreateWorktree call
+	git := &failOnNthWorktreeMock{
+		mockGitClient: newMockGitClient(),
+		failOnCall:    2,
+	}
+
+	cfg := Config{Count: 3, BranchPrefix: "orbit-impl"}
+	mgr, err := NewManager(cfg, "test-spec", specDir, tmpDir, git)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	ctx := context.Background()
+	err = mgr.Setup(ctx, false)
+	if err == nil {
+		t.Fatal("expected error from Setup")
+	}
+
+	// Branch 1 was created with its worktree, branch 2 was created but worktree failed.
+	// Both branches must be deleted.
+	if len(git.mockGitClient.deletedBranches) != 2 {
+		t.Errorf("expected 2 deleted branches, got %d: %v",
+			len(git.mockGitClient.deletedBranches), git.mockGitClient.deletedBranches)
+	}
+
+	// Only worktree 1 was successfully created, so only it should be removed.
+	if len(git.mockGitClient.removedWorktrees) != 1 {
+		t.Errorf("expected 1 removed worktree, got %d: %v",
+			len(git.mockGitClient.removedWorktrees), git.mockGitClient.removedWorktrees)
+	}
+}
+
+// failOnNthBranchMock wraps mockGitClient but fails CreateBranch on the Nth call.
+type failOnNthBranchMock struct {
+	*mockGitClient
+	failOnCall int
+	callCount  int
+}
+
+func (m *failOnNthBranchMock) CreateBranch(name, commit string) error {
+	m.callCount++
+	if m.callCount == m.failOnCall {
+		return fmt.Errorf("simulated branch creation failure")
+	}
+	return m.mockGitClient.CreateBranch(name, commit)
+}
+
+// failOnNthWorktreeMock wraps mockGitClient but fails CreateWorktree on the Nth call.
+type failOnNthWorktreeMock struct {
+	*mockGitClient
+	failOnCall int
+	callCount  int
+}
+
+func (m *failOnNthWorktreeMock) CreateWorktree(ctx context.Context, path, branch string) error {
+	m.callCount++
+	if m.callCount == m.failOnCall {
+		return fmt.Errorf("simulated worktree creation failure")
+	}
+	return m.mockGitClient.CreateWorktree(ctx, path, branch)
 }
 
 func contains(s, substr string) bool {

--- a/internal/variants/manager_test.go
+++ b/internal/variants/manager_test.go
@@ -1574,15 +1574,15 @@ func TestSetup_CleansUpBranchesOnPartialFailure(t *testing.T) {
 
 	// Branches 1 and 2 were created successfully before branch 3 failed.
 	// They must be deleted during cleanup.
-	if len(git.mockGitClient.deletedBranches) != 2 {
+	if len(git.deletedBranches) != 2 {
 		t.Errorf("expected 2 deleted branches, got %d: %v",
-			len(git.mockGitClient.deletedBranches), git.mockGitClient.deletedBranches)
+			len(git.deletedBranches), git.deletedBranches)
 	}
 
 	// Worktrees 1 and 2 were also created and must be removed.
-	if len(git.mockGitClient.removedWorktrees) != 2 {
+	if len(git.removedWorktrees) != 2 {
 		t.Errorf("expected 2 removed worktrees, got %d: %v",
-			len(git.mockGitClient.removedWorktrees), git.mockGitClient.removedWorktrees)
+			len(git.removedWorktrees), git.removedWorktrees)
 	}
 }
 
@@ -1612,15 +1612,15 @@ func TestSetup_CleansUpBranchesOnWorktreeFailure(t *testing.T) {
 
 	// Branch 1 was created with its worktree, branch 2 was created but worktree failed.
 	// Both branches must be deleted.
-	if len(git.mockGitClient.deletedBranches) != 2 {
+	if len(git.deletedBranches) != 2 {
 		t.Errorf("expected 2 deleted branches, got %d: %v",
-			len(git.mockGitClient.deletedBranches), git.mockGitClient.deletedBranches)
+			len(git.deletedBranches), git.deletedBranches)
 	}
 
 	// Only worktree 1 was successfully created, so only it should be removed.
-	if len(git.mockGitClient.removedWorktrees) != 1 {
+	if len(git.removedWorktrees) != 1 {
 		t.Errorf("expected 1 removed worktree, got %d: %v",
-			len(git.mockGitClient.removedWorktrees), git.mockGitClient.removedWorktrees)
+			len(git.removedWorktrees), git.removedWorktrees)
 	}
 }
 


### PR DESCRIPTION
Extends cleanup on variant setup failure to also delete branches that were created before the failure.

**Changes:**
- internal/variants/manager.go: Extended cleanupCreated to handle branches
- internal/variants/manager_test.go: Added partial failure cleanup tests

Fixes T-821