### PR TITLE
Fix T-751: Consolidation panic on nil result

### DIFF
--- a/internal/consolidation/consolidator.go
+++ b/internal/consolidation/consolidator.go
@@ -538,7 +538,7 @@ func (c *Consolidator) runWithRetry(ctx context.Context, prompt string) (*agents
 			// Nil result with no error is unexpected — treat as retryable transient glitch.
 			if err == nil && result == nil {
 				return &agents.ClassifiedError{
-					Original: fmt.Errorf("agent returned nil result"),
+					Original: errors.New("agent returned nil result"),
 					Class:    agents.ErrorClassRetryable,
 					Message:  "agent returned nil result without error",
 				}

--- a/internal/consolidation/consolidator.go
+++ b/internal/consolidation/consolidator.go
@@ -530,10 +530,18 @@ func (c *Consolidator) runWithRetry(ctx context.Context, prompt string) (*agents
 			return c.config.Agent.Run(runCtx, opts)
 		},
 		Classify: func(result *agents.RunResult, err error) *agents.ClassifiedError {
-			// Success: no error and agent did not report an error condition.
-			// Uses IsError (not result.Error) to match classifyFromAgent behavior.
-			if err == nil && (result == nil || !result.IsError) {
+			// Success: no error, non-nil result, and agent did not report an error condition.
+			if err == nil && result != nil && !result.IsError {
 				return nil
+			}
+
+			// Nil result with no error is unexpected — treat as fatal to avoid nil dereference.
+			if err == nil && result == nil {
+				return &agents.ClassifiedError{
+					Original: fmt.Errorf("agent returned nil result"),
+					Class:    agents.ErrorClassRetryable,
+					Message:  "agent returned nil result without error",
+				}
 			}
 
 			classifier := agents.GetClassifier(c.config.Agent.Name())

--- a/internal/consolidation/consolidator.go
+++ b/internal/consolidation/consolidator.go
@@ -535,7 +535,7 @@ func (c *Consolidator) runWithRetry(ctx context.Context, prompt string) (*agents
 				return nil
 			}
 
-			// Nil result with no error is unexpected — treat as fatal to avoid nil dereference.
+			// Nil result with no error is unexpected — treat as retryable transient glitch.
 			if err == nil && result == nil {
 				return &agents.ClassifiedError{
 					Original: fmt.Errorf("agent returned nil result"),

--- a/internal/consolidation/consolidator_test.go
+++ b/internal/consolidation/consolidator_test.go
@@ -1188,9 +1188,9 @@ func TestRunWithRetry_IsErrorTreatedAsFailure(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		"nil result should succeed": {
+		"nil result should fail": {
 			result:  nil,
-			wantErr: false,
+			wantErr: true,
 		},
 		"Go-level error should fail": {
 			result:  &agents.RunResult{SessionID: "test-session", ExitCode: 1},

--- a/internal/consolidation/consolidator_test.go
+++ b/internal/consolidation/consolidator_test.go
@@ -1188,7 +1188,7 @@ func TestRunWithRetry_IsErrorTreatedAsFailure(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		"nil result should fail": {
+		"nil result should fail (T-751)": {
 			result:  nil,
 			wantErr: true,
 		},
@@ -1221,7 +1221,12 @@ func TestRunWithRetry_IsErrorTreatedAsFailure(t *testing.T) {
 			consolidator, err := NewConsolidator(cfg, mgr)
 			require.NoError(t, err)
 
-			_, err = consolidator.runWithRetry(context.Background(), "test prompt")
+			// Use a short timeout to bound retries for retryable error cases
+			// (e.g., nil result) that would otherwise sleep ~15s with real backoff.
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+
+			_, err = consolidator.runWithRetry(ctx, "test prompt")
 			if tc.wantErr {
 				assert.Error(t, err, "runWithRetry should return error")
 			} else {


### PR DESCRIPTION
Prevents nil pointer panic in consolidation retry logic by classifying nil results as retryable.

**Changes:**
- internal/consolidation/consolidator.go: Added nil check in Classify callback
- internal/consolidation/consolidator_test.go: Updated test expectations

Fixes T-751