### PR TITLE
Fix T-778: Post-prompt spinner not stopped on early failure

### DIFF
--- a/internal/orbit/single.go
+++ b/internal/orbit/single.go
@@ -279,8 +279,11 @@ func (o *Orbit) runPostPrompt() error {
 		var err error
 		sessionID, isResume, err = o.logManager.StartPostCompletion(o.config.ContinueSession)
 		if err != nil {
+			if o.spinner != nil {
+				o.spinner.Stop()
+			}
 			o.debug.Log("Failed to start post-completion in log manager: %v", err)
-			return o.fail(fmt.Errorf("failed to start post-completion: %w", err))
+			return fmt.Errorf("failed to start post-completion: %w", err)
 		}
 		o.debug.LogSession(sessionID, isResume, "post-completion obtained from log manager")
 	} else {

--- a/internal/orbit/single.go
+++ b/internal/orbit/single.go
@@ -543,8 +543,11 @@ func (o *Orbit) runPhase(phase int) error {
 		var err error
 		sessionID, isResume, err = o.logManager.StartPhase(phase, o.config.ContinueSession, overrideSessionID)
 		if err != nil {
+			if o.spinner != nil {
+				o.spinner.Stop()
+			}
 			o.debug.Log("Failed to start phase in log manager: %v", err)
-			return o.fail(fmt.Errorf("failed to start phase: %w", err))
+			return fmt.Errorf("failed to start phase: %w", err)
 		}
 		o.debug.LogSession(sessionID, isResume, "obtained from log manager")
 	} else {


### PR DESCRIPTION
Stops the post-prompt spinner explicitly on early setup failure and fixes the same pattern in runPhase().

**Changes:**
- internal/orbit/single.go: Added spinner.Stop() before returning error in runPostPrompt()
- internal/orbit/single.go: Replaced `o.fail()` with `fmt.Errorf` in both runPostPrompt() and runPhase() early returns to prevent double-fail invocation (the caller already calls `o.fail()` on the propagated error)
- internal/orbit/single.go: Added spinner.Stop() before returning error in runPhase() (same bug)

**Why remove o.fail():**
The `o.fail()` call was causing double invocation of failure side effects (spinner stop, debug log shutdown, registry update, logManager.Fail, index link printing) because the caller (`runSingle()`) also calls `o.fail()` on the propagated error. Returning a plain `fmt.Errorf` matches the pattern used in `runPrePrompt()`.

Fixes T-778