### PR TITLE
Fix T-764: runComparison ignores caller context

### DIFF
--- a/internal/orbit/comparison.go
+++ b/internal/orbit/comparison.go
@@ -52,7 +52,7 @@ func (o *Orbit) runComparison(ctx context.Context) error {
 	if comparisonTimeout <= 0 {
 		comparisonTimeout = comparison.DefaultTimeout
 	}
-	comparisonCtx, cancel := context.WithTimeout(o.shutdownCtx, comparisonTimeout)
+	comparisonCtx, cancel := context.WithTimeout(ctx, comparisonTimeout)
 	defer cancel()
 
 	adapter := comparison.NewAgentAdapter(o.agent, o.config.WorkingDir).


### PR DESCRIPTION
Changes runComparison to use the caller's context instead of always deriving from shutdownCtx.

**Changes:**
- internal/orbit/comparison.go: Changed context.WithTimeout parent from o.shutdownCtx to ctx

Fixes T-764