### PR TITLE
Fix T-740: OpenCode DiscoverSessions ignores projectDir filter

### DIFF
--- a/internal/agents/opencode/agent.go
+++ b/internal/agents/opencode/agent.go
@@ -210,7 +210,7 @@ func discoverSessionsIn(ctx context.Context, sessionDir string, projectDir strin
 		sessionID := entry.Name()
 
 		// Skip sessions not belonging to the requested project.
-		if allowedIDs != nil {
+		if projectDir != "" {
 			if _, ok := allowedIDs[sessionID]; !ok {
 				continue
 			}
@@ -283,6 +283,13 @@ func sessionIDsForProject(messageDir, projectDir string) map[string]struct{} {
 		return nil
 	}
 
+	// Resolve projectDir for symlink-safe comparison (e.g. macOS /var → /private/var).
+	cleanProjectDir := filepath.Clean(projectDir)
+	resolvedProjectDir, err := filepath.EvalSymlinks(cleanProjectDir)
+	if err != nil {
+		resolvedProjectDir = cleanProjectDir
+	}
+
 	// Find the project ID whose worktree matches projectDir.
 	var projectID string
 	for _, entry := range entries {
@@ -300,7 +307,12 @@ func sessionIDsForProject(messageDir, projectDir string) map[string]struct{} {
 		if err := json.Unmarshal(data, &proj); err != nil {
 			continue
 		}
-		if filepath.Clean(proj.Worktree) == filepath.Clean(projectDir) {
+		cleanWorktree := filepath.Clean(proj.Worktree)
+		resolvedWorktree, err := filepath.EvalSymlinks(cleanWorktree)
+		if err != nil {
+			resolvedWorktree = cleanWorktree
+		}
+		if resolvedWorktree == resolvedProjectDir {
 			projectID = proj.ID
 			break
 		}

--- a/internal/agents/opencode/agent.go
+++ b/internal/agents/opencode/agent.go
@@ -300,7 +300,7 @@ func sessionIDsForProject(messageDir, projectDir string) map[string]struct{} {
 		if err := json.Unmarshal(data, &proj); err != nil {
 			continue
 		}
-		if proj.Worktree == projectDir {
+		if filepath.Clean(proj.Worktree) == filepath.Clean(projectDir) {
 			projectID = proj.ID
 			break
 		}

--- a/internal/agents/opencode/agent.go
+++ b/internal/agents/opencode/agent.go
@@ -168,13 +168,23 @@ func (a *Agent) DiscoverSessions(ctx context.Context, projectDir string) ([]agen
 		return nil, nil
 	}
 
-	return discoverSessionsIn(ctx, sessionDir)
+	return discoverSessionsIn(ctx, sessionDir, projectDir)
 }
 
 // discoverSessionsIn scans sessionDir for OpenCode session subdirectories and
-// returns session metadata for each. Extracted from DiscoverSessions to allow
+// returns session metadata for each. When projectDir is non-empty, only sessions
+// belonging to that project are returned. Extracted from DiscoverSessions to allow
 // testing with arbitrary directories.
-func discoverSessionsIn(ctx context.Context, sessionDir string) ([]agents.SessionInfo, error) {
+func discoverSessionsIn(ctx context.Context, sessionDir string, projectDir string) ([]agents.SessionInfo, error) {
+	// Build a set of allowed session IDs when filtering by project.
+	var allowedIDs map[string]struct{}
+	if projectDir != "" {
+		allowedIDs = sessionIDsForProject(sessionDir, projectDir)
+		if len(allowedIDs) == 0 {
+			return nil, nil
+		}
+	}
+
 	// Sessions are stored in ~/.local/share/opencode/storage/message/<sessionID>/
 	entries, err := os.ReadDir(sessionDir)
 	if err != nil {
@@ -198,6 +208,14 @@ func discoverSessionsIn(ctx context.Context, sessionDir string) ([]agents.Sessio
 		}
 
 		sessionID := entry.Name()
+
+		// Skip sessions not belonging to the requested project.
+		if allowedIDs != nil {
+			if _, ok := allowedIDs[sessionID]; !ok {
+				continue
+			}
+		}
+
 		sessionPath := filepath.Join(sessionDir, sessionID)
 
 		// Read the first message file to get metadata
@@ -250,6 +268,62 @@ func discoverSessionsIn(ctx context.Context, sessionDir string) ([]agents.Sessio
 	}
 
 	return sessions, nil
+}
+
+// sessionIDsForProject returns the set of session IDs belonging to projectDir.
+// It looks up the project ID from storage/project/*.json, then lists session
+// files in storage/session/{projectID}/.
+func sessionIDsForProject(messageDir, projectDir string) map[string]struct{} {
+	// messageDir is storage/message; go up to storage/
+	storageDir := filepath.Dir(messageDir)
+	projectsDir := filepath.Join(storageDir, "project")
+
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return nil
+	}
+
+	// Find the project ID whose worktree matches projectDir.
+	var projectID string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(projectsDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var proj struct {
+			ID       string `json:"id"`
+			Worktree string `json:"worktree"`
+		}
+		if err := json.Unmarshal(data, &proj); err != nil {
+			continue
+		}
+		if proj.Worktree == projectDir {
+			projectID = proj.ID
+			break
+		}
+	}
+	if projectID == "" {
+		return nil
+	}
+
+	// List session files in storage/session/{projectID}/
+	sessDir := filepath.Join(storageDir, "session", projectID)
+	sessEntries, err := os.ReadDir(sessDir)
+	if err != nil {
+		return nil
+	}
+
+	ids := make(map[string]struct{}, len(sessEntries))
+	for _, e := range sessEntries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		ids[strings.TrimSuffix(e.Name(), ".json")] = struct{}{}
+	}
+	return ids
 }
 
 // Run executes a prompt in a new session.

--- a/internal/agents/opencode/agent_test.go
+++ b/internal/agents/opencode/agent_test.go
@@ -483,6 +483,12 @@ func TestDiscoverSessions_FiltersByProjectDir(t *testing.T) {
 	require.Len(t, filtered, 1)
 	assert.Equal(t, "ses_A", filtered[0].ID)
 
+	// Trailing slash on caller side must still match.
+	trailingSlash, err := discoverSessionsIn(t.Context(), messageDir, "/fake/projectA/")
+	require.NoError(t, err)
+	require.Len(t, trailingSlash, 1)
+	assert.Equal(t, "ses_A", trailingSlash[0].ID)
+
 	// With unknown project: returns nil.
 	none, err := discoverSessionsIn(t.Context(), messageDir, "/fake/unknown")
 	require.NoError(t, err)

--- a/internal/agents/opencode/agent_test.go
+++ b/internal/agents/opencode/agent_test.go
@@ -366,7 +366,7 @@ func TestDiscoverSessions_CreatedAtFallbackToModTime(t *testing.T) {
 	// Write a non-message file so the directory isn't empty.
 	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "metadata.json"), []byte(`{}`), 0o644))
 
-	sessions, err := discoverSessionsIn(t.Context(), tmp)
+	sessions, err := discoverSessionsIn(t.Context(), tmp, "")
 	require.NoError(t, err)
 	require.Len(t, sessions, 1, "expected exactly one session")
 
@@ -393,7 +393,7 @@ func TestDiscoverSessions_ParseCreatedTimeFallbackOnBadTimestamp(t *testing.T) {
 	badMsg := `{"id":"msg_1","sessionID":"ses_bad_timestamps","role":"user","time":{"created":"not-a-timestamp"}}`
 	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "msg_001.json"), []byte(badMsg), 0o644))
 
-	sessions, err := discoverSessionsIn(t.Context(), tmp)
+	sessions, err := discoverSessionsIn(t.Context(), tmp, "")
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 
@@ -422,13 +422,71 @@ func TestDiscoverSessions_CreatedAtFallbackWhenAllMsgFilesUnreadable(t *testing.
 		0o644,
 	))
 
-	sessions, err := discoverSessionsIn(t.Context(), tmp)
+	sessions, err := discoverSessionsIn(t.Context(), tmp, "")
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 
 	session := sessions[0]
 	assert.False(t, session.CreatedAt.IsZero(),
 		"CreatedAt must not be zero when all msg_ files fail to unmarshal; should fall back to directory modTime")
+}
+
+// TestDiscoverSessions_FiltersbyProjectDir verifies that when a projectDir is
+// provided, only sessions belonging to that project are returned.
+// Regression test for T-740.
+func TestDiscoverSessions_FiltersByProjectDir(t *testing.T) {
+	t.Parallel()
+
+	// Build a fake storage tree:
+	// tmp/storage/message/ses_A/msg_001.json  (belongs to projectA)
+	// tmp/storage/message/ses_B/msg_001.json  (belongs to projectB)
+	// tmp/storage/project/proj1.json          (worktree: /fake/projectA)
+	// tmp/storage/session/proj1/ses_A.json
+	// tmp/storage/session/proj2/ses_B.json
+	tmp := t.TempDir()
+	storageDir := filepath.Join(tmp, "storage")
+	messageDir := filepath.Join(storageDir, "message")
+	projectDir := filepath.Join(storageDir, "project")
+	sessionDir := filepath.Join(storageDir, "session")
+
+	// Create message directories.
+	for _, ses := range []string{"ses_A", "ses_B"} {
+		dir := filepath.Join(messageDir, ses)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		msg := `{"id":"msg_1","sessionID":"` + ses + `","role":"user","time":{"created":"2026-01-01T00:00:00Z"}}`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "msg_001.json"), []byte(msg), 0o644))
+	}
+
+	// Create project files.
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "proj1.json"),
+		[]byte(`{"id":"proj1","worktree":"/fake/projectA"}`), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "proj2.json"),
+		[]byte(`{"id":"proj2","worktree":"/fake/projectB"}`), 0o644))
+
+	// Create session index directories.
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionDir, "proj1"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionDir, "proj2"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "proj1", "ses_A.json"), []byte(`{}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "proj2", "ses_B.json"), []byte(`{}`), 0o644))
+
+	// Without filter: returns both sessions.
+	all, err := discoverSessionsIn(t.Context(), messageDir, "")
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	// With projectA filter: returns only ses_A.
+	filtered, err := discoverSessionsIn(t.Context(), messageDir, "/fake/projectA")
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "ses_A", filtered[0].ID)
+
+	// With unknown project: returns nil.
+	none, err := discoverSessionsIn(t.Context(), messageDir, "/fake/unknown")
+	require.NoError(t, err)
+	assert.Empty(t, none)
 }
 
 // TestParseCreatedTime_ZeroUnixReturnsFallback verifies that a created time

--- a/internal/agents/opencode/agent_test.go
+++ b/internal/agents/opencode/agent_test.go
@@ -431,7 +431,7 @@ func TestDiscoverSessions_CreatedAtFallbackWhenAllMsgFilesUnreadable(t *testing.
 		"CreatedAt must not be zero when all msg_ files fail to unmarshal; should fall back to directory modTime")
 }
 
-// TestDiscoverSessions_FiltersbyProjectDir verifies that when a projectDir is
+// TestDiscoverSessions_FiltersByProjectDir verifies that when a projectDir is
 // provided, only sessions belonging to that project are returned.
 // Regression test for T-740.
 func TestDiscoverSessions_FiltersByProjectDir(t *testing.T) {


### PR DESCRIPTION
Adds projectDir filtering to the OpenCode agent's DiscoverSessions method using project storage metadata.

**Changes:**
- internal/agents/opencode/agent.go: Added sessionIDsForProject helper and filtering
- internal/agents/opencode/agent_test.go: Added TestDiscoverSessions_FiltersByProjectDir

Fixes T-740