### PR TITLE
Fix T-792: Apsis session listers include symlink escapes

### DIFF
--- a/internal/sessions/lister.go
+++ b/internal/sessions/lister.go
@@ -138,8 +138,17 @@ func (l *Lister) listClaudeDir(projectDir string) ([]SessionInfo, error) {
 			continue
 		}
 
-		sessionID := strings.TrimSuffix(entry.Name(), ".jsonl")
 		filePath := filepath.Join(projectDir, entry.Name())
+
+		// Skip symlinks that escape the project directory.
+		if entry.Type()&fs.ModeSymlink != 0 {
+			resolved, err := filepath.EvalSymlinks(filePath)
+			if err != nil || !isWithinDir(resolved, projectDir) {
+				continue
+			}
+		}
+
+		sessionID := strings.TrimSuffix(entry.Name(), ".jsonl")
 
 		info, err := entry.Info()
 		if err != nil {
@@ -381,6 +390,15 @@ func (l *Lister) listKiroIDE(projectPath string) ([]SessionInfo, error) {
 		}
 
 		path := filepath.Join(workspaceDir, entry.Name())
+
+		// Skip symlinks that escape the workspace directory.
+		if entry.Type()&fs.ModeSymlink != 0 {
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil || !isWithinDir(resolved, workspaceDir) {
+				continue
+			}
+		}
+
 		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
@@ -578,12 +596,18 @@ func normalizePath(p string) string {
 }
 
 // walkDirFollowSymlinks walks a directory tree, following symlinks with cycle detection.
+// Symlinks that resolve outside the root directory are skipped.
 func walkDirFollowSymlinks(root string, fn fs.WalkDirFunc) error {
 	visited := make(map[string]bool)
-	return walkDirFollowSymlinksInternal(root, fn, visited)
+	boundary, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		boundary = root
+	}
+	boundary, _ = filepath.Abs(boundary)
+	return walkDirFollowSymlinksInternal(root, boundary, fn, visited)
 }
 
-func walkDirFollowSymlinksInternal(root string, fn fs.WalkDirFunc, visited map[string]bool) error {
+func walkDirFollowSymlinksInternal(root, boundary string, fn fs.WalkDirFunc, visited map[string]bool) error {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return err
@@ -602,12 +626,16 @@ func walkDirFollowSymlinksInternal(root string, fn fs.WalkDirFunc, visited map[s
 		if d.Type()&fs.ModeSymlink != 0 {
 			realPath, err := filepath.EvalSymlinks(path)
 			if err != nil {
-				return fn(path, d, err)
+				return nil // skip unresolvable symlinks
+			}
+
+			if !isWithinDir(realPath, boundary) {
+				return nil // skip symlinks escaping the boundary
 			}
 
 			info, err := os.Stat(realPath)
 			if err != nil {
-				return fn(path, d, err)
+				return nil
 			}
 
 			if info.IsDir() {
@@ -615,7 +643,7 @@ func walkDirFollowSymlinksInternal(root string, fn fs.WalkDirFunc, visited map[s
 				if visited[absReal] {
 					return nil
 				}
-				return walkDirFollowSymlinksInternal(realPath, fn, visited)
+				return walkDirFollowSymlinksInternal(realPath, boundary, fn, visited)
 			}
 
 			return fn(realPath, fs.FileInfoToDirEntry(info), nil)
@@ -623,6 +651,23 @@ func walkDirFollowSymlinksInternal(root string, fn fs.WalkDirFunc, visited map[s
 
 		return fn(path, d, err)
 	})
+}
+
+// isWithinDir reports whether path is within dir after resolving symlinks.
+func isWithinDir(path, dir string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absDir, absPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // sortSessionsByTimestamp sorts sessions by creation time (oldest first).

--- a/internal/sessions/lister.go
+++ b/internal/sessions/lister.go
@@ -597,13 +597,17 @@ func normalizePath(p string) string {
 
 // walkDirFollowSymlinks walks a directory tree, following symlinks with cycle detection.
 // Symlinks that resolve outside the root directory are skipped.
+// Unresolvable symlinks (broken, permission errors) are silently skipped rather than
+// propagated to fn, since callers treat missing sessions as non-fatal.
 func walkDirFollowSymlinks(root string, fn fs.WalkDirFunc) error {
 	visited := make(map[string]bool)
 	boundary, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		boundary = root
 	}
-	boundary, _ = filepath.Abs(boundary)
+	if abs, err := filepath.Abs(boundary); err == nil {
+		boundary = abs
+	}
 	return walkDirFollowSymlinksInternal(root, boundary, fn, visited)
 }
 
@@ -653,13 +657,20 @@ func walkDirFollowSymlinksInternal(root, boundary string, fn fs.WalkDirFunc, vis
 	})
 }
 
-// isWithinDir reports whether path is within dir after resolving symlinks.
+// isWithinDir reports whether path is within dir.
+// Both path and dir are resolved via EvalSymlinks before comparison so that
+// symlinked prefixes (e.g. /tmp → /private/tmp on macOS) do not cause
+// false negatives.
 func isWithinDir(path, dir string) bool {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return false
 	}
-	absDir, err := filepath.Abs(dir)
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		resolvedDir = dir
+	}
+	absDir, err := filepath.Abs(resolvedDir)
 	if err != nil {
 		return false
 	}

--- a/internal/sessions/lister_test.go
+++ b/internal/sessions/lister_test.go
@@ -923,3 +923,84 @@ func TestListKiroUsesCreatedAtNotUpdatedAt(t *testing.T) {
 		t.Errorf("session.Size = %d, want %d", s.Size, 1024)
 	}
 }
+
+// TestListCodexSkipsSymlinkEscape verifies that Codex session listing does not
+// follow symlinks that resolve outside the sessions directory (T-792).
+func TestListCodexSkipsSymlinkEscape(t *testing.T) {
+	homeDir := t.TempDir()
+	projectPath := t.TempDir()
+
+	// Create a legitimate session inside the codex sessions dir.
+	createdAt := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	setupCodexSession(t, homeDir, projectPath, "legit-session-id", createdAt)
+
+	// Create an outside directory with a session file that should NOT be discovered.
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "escaped-session.jsonl")
+	meta := fmt.Sprintf(`{"type":"session_meta","timestamp":"2025-03-02T10:00:00Z","payload":{"id":"escaped-id","cwd":"%s"}}`, projectPath)
+	if err := os.WriteFile(outsideFile, []byte(meta+"\n"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	// Create a symlink inside the codex sessions dir pointing outside.
+	codexDir := filepath.Join(homeDir, ".codex", "sessions")
+	symlink := filepath.Join(codexDir, "escape-link")
+	if err := os.Symlink(outsideDir, symlink); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	lister := newTestLister(homeDir)
+	sessions, err := lister.listCodex(projectPath)
+	if err != nil {
+		t.Fatalf("listCodex error: %v", err)
+	}
+
+	// Only the legitimate session should be found.
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if !strings.Contains(sessions[0].ID, "legit-session-id") {
+		t.Errorf("session.ID = %q, want it to contain %q", sessions[0].ID, "legit-session-id")
+	}
+}
+
+// TestListClaudeSkipsSymlinkEscape verifies that Claude session listing does not
+// follow symlinks that escape the project directory (T-792).
+func TestListClaudeSkipsSymlinkEscape(t *testing.T) {
+	homeDir := t.TempDir()
+	projectPath := t.TempDir()
+
+	// Create a legitimate session.
+	createdAt := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	setupClaudeSession(t, homeDir, projectPath, "legit-session", createdAt)
+
+	// Create an outside file that should NOT be discovered.
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "escaped.jsonl")
+	entry := `{"type":"system","timestamp":"2025-03-02T10:00:00Z","message":"escaped"}`
+	if err := os.WriteFile(outsideFile, []byte(entry+"\n"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	// Create a symlink inside the Claude project dir pointing to the outside file.
+	claudeProjectPath := claudecode.BuildProjectPath(projectPath)
+	projectDir := filepath.Join(homeDir, ".claude", "projects", claudeProjectPath)
+	symlink := filepath.Join(projectDir, "escaped.jsonl")
+	if err := os.Symlink(outsideFile, symlink); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	lister := newTestLister(homeDir)
+	sessions, err := lister.listClaudeDir(projectDir)
+	if err != nil {
+		t.Fatalf("listClaudeDir error: %v", err)
+	}
+
+	// Only the legitimate session should be found.
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].ID != "legit-session" {
+		t.Errorf("session.ID = %q, want %q", sessions[0].ID, "legit-session")
+	}
+}

--- a/internal/sessions/lister_test.go
+++ b/internal/sessions/lister_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1002,5 +1003,164 @@ func TestListClaudeSkipsSymlinkEscape(t *testing.T) {
 	}
 	if sessions[0].ID != "legit-session" {
 		t.Errorf("session.ID = %q, want %q", sessions[0].ID, "legit-session")
+	}
+}
+
+// TestListKiroIDESkipsSymlinkEscape verifies that Kiro IDE session listing does not
+// follow symlinks that escape the workspace directory (T-792).
+func TestListKiroIDESkipsSymlinkEscape(t *testing.T) {
+	homeDir := t.TempDir()
+
+	// Create a fake workspace directory structure.
+	workspaceDir := filepath.Join(homeDir, ".kiro", "workspace")
+	if err := os.MkdirAll(workspaceDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Create a legitimate .chat file inside the workspace.
+	legitChat := map[string]any{
+		"executionId": "legit-exec-id",
+		"chat":        []map[string]any{{"role": "user", "content": "hello"}},
+		"metadata":    map[string]any{"startTime": 1700000000000},
+	}
+	legitData, _ := json.Marshal(legitChat)
+	if err := os.WriteFile(filepath.Join(workspaceDir, "legit.chat"), legitData, 0644); err != nil {
+		t.Fatalf("write legit chat: %v", err)
+	}
+
+	// Create an outside directory with a .chat file that should NOT be discovered.
+	outsideDir := t.TempDir()
+	escapedChat := map[string]any{
+		"executionId": "escaped-exec-id",
+		"chat":        []map[string]any{{"role": "user", "content": "escaped"}},
+		"metadata":    map[string]any{"startTime": 1700000001000},
+	}
+	escapedData, _ := json.Marshal(escapedChat)
+	outsideFile := filepath.Join(outsideDir, "escaped.chat")
+	if err := os.WriteFile(outsideFile, escapedData, 0644); err != nil {
+		t.Fatalf("write outside chat: %v", err)
+	}
+
+	// Create a symlink inside the workspace pointing to the outside file.
+	symlink := filepath.Join(workspaceDir, "escaped.chat")
+	if err := os.Symlink(outsideFile, symlink); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	// Read the workspace directory directly (bypass KiroIDEWorkspaceDir lookup).
+	entries, err := os.ReadDir(workspaceDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+
+	// Simulate what listKiroIDE does: iterate entries and check symlinks.
+	var foundIDs []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".chat") {
+			continue
+		}
+		path := filepath.Join(workspaceDir, entry.Name())
+		if entry.Type()&os.ModeSymlink != 0 {
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil || !isWithinDir(resolved, workspaceDir) {
+				continue
+			}
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var header struct {
+			ExecutionID string `json:"executionId"`
+		}
+		if err := json.Unmarshal(data, &header); err != nil {
+			continue
+		}
+		foundIDs = append(foundIDs, header.ExecutionID)
+	}
+
+	if len(foundIDs) != 1 {
+		t.Fatalf("expected 1 session, got %d: %v", len(foundIDs), foundIDs)
+	}
+	if foundIDs[0] != "legit-exec-id" {
+		t.Errorf("found ID = %q, want %q", foundIDs[0], "legit-exec-id")
+	}
+}
+
+// TestWalkDirFollowSymlinksSkipsEscape verifies that walkDirFollowSymlinks
+// does not follow symlinks that resolve outside the root directory (T-792).
+func TestWalkDirFollowSymlinksSkipsEscape(t *testing.T) {
+	root := t.TempDir()
+
+	// Create a legitimate file inside root.
+	if err := os.WriteFile(filepath.Join(root, "legit.jsonl"), []byte("data\n"), 0644); err != nil {
+		t.Fatalf("write legit file: %v", err)
+	}
+
+	// Create an outside directory with a file that should NOT be walked.
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "escaped.jsonl")
+	if err := os.WriteFile(outsideFile, []byte("escaped\n"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	// Create a symlink inside root pointing to the outside directory.
+	symlink := filepath.Join(root, "escape-link")
+	if err := os.Symlink(outsideDir, symlink); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	var visited []string
+	err := walkDirFollowSymlinks(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			visited = append(visited, filepath.Base(path))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walkDirFollowSymlinks error: %v", err)
+	}
+
+	// Only the legitimate file should be visited.
+	if len(visited) != 1 {
+		t.Fatalf("expected 1 visited file, got %d: %v", len(visited), visited)
+	}
+	if visited[0] != "legit.jsonl" {
+		t.Errorf("visited[0] = %q, want %q", visited[0], "legit.jsonl")
+	}
+}
+
+// TestIsWithinDirResolvesSymlinkedPrefix verifies that isWithinDir correctly
+// handles the case where dir itself is under a symlinked prefix (e.g. /tmp →
+// /private/tmp on macOS). This is a regression test for the false-negative
+// reported in the T-792 review.
+func TestIsWithinDirResolvesSymlinkedPrefix(t *testing.T) {
+	// Create a real directory and a symlink to it.
+	realDir := t.TempDir()
+	symlinkParent := t.TempDir()
+	symlinkDir := filepath.Join(symlinkParent, "link")
+	if err := os.Symlink(realDir, symlinkDir); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	// Create a file inside the real directory.
+	filePath := filepath.Join(realDir, "test.jsonl")
+	if err := os.WriteFile(filePath, []byte("data\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Resolve the file path (simulating what EvalSymlinks returns).
+	resolvedFile, err := filepath.EvalSymlinks(filePath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks file: %v", err)
+	}
+
+	// isWithinDir should return true when dir is the symlink path and
+	// path is the resolved real path.
+	if !isWithinDir(resolvedFile, symlinkDir) {
+		t.Errorf("isWithinDir(%q, %q) = false, want true", resolvedFile, symlinkDir)
 	}
 }


### PR DESCRIPTION
Adds symlink boundary checking to session listing functions, preventing symlinks that escape the expected directory.

**Changes:**
- internal/sessions/lister.go: Added boundary parameter and isWithinDir helper
- internal/sessions/lister_test.go: Added symlink escape tests

Fixes T-792