### PR TITLE
Fix T-800: Copilot parser drops interrupted assistant turns

### DIFF
--- a/internal/transcript/copilot_parser.go
+++ b/internal/transcript/copilot_parser.go
@@ -174,5 +174,18 @@ func convertCopilotToEntries(events []CopilotEvent) []Entry {
 		}
 	}
 
+	// Flush any incomplete assistant turn (interrupted session without turn_end)
+	if inAssistantTurn && len(currentTurnContent) > 0 {
+		entries = append(entries, Entry{
+			Type:      "assistant",
+			Timestamp: currentTurnTimestamp,
+			Model:     currentModel,
+			Message: &Message{
+				Role:    "assistant",
+				Content: currentTurnContent,
+			},
+		})
+	}
+
 	return entries
 }

--- a/internal/transcript/copilot_parser_test.go
+++ b/internal/transcript/copilot_parser_test.go
@@ -192,3 +192,24 @@ func TestParseCopilot_ModelOnlyOnAssistantEntries(t *testing.T) {
 		}
 	}
 }
+
+func TestParseCopilot_InterruptedAssistantTurnPreserved(t *testing.T) {
+	// When a session is interrupted (no turn_end), the assistant content should still be preserved
+	input := `{"type":"session.start","data":{"sessionId":"s1"},"id":"1","timestamp":"2026-01-17T12:00:00Z"}
+{"type":"session.model_change","data":{"model":"gpt-4o"},"id":"2","timestamp":"2026-01-17T12:00:00.500Z"}
+{"type":"user.message","data":{"content":"hello"},"id":"3","timestamp":"2026-01-17T12:00:01Z"}
+{"type":"assistant.turn_start","data":{"turnId":"0"},"id":"4","timestamp":"2026-01-17T12:00:02Z"}
+{"type":"assistant.message","data":{"messageId":"m1","content":"partial response"},"id":"5","timestamp":"2026-01-17T12:00:03Z"}`
+
+	result, err := ParseCopilot(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 2, "should have user + interrupted assistant entry")
+
+	assert.Equal(t, "user", result.Entries[0].Type)
+	assert.Equal(t, "assistant", result.Entries[1].Type)
+	assert.Equal(t, "2026-01-17T12:00:02Z", result.Entries[1].Timestamp)
+	assert.Equal(t, "gpt-4o", result.Entries[1].Model)
+	require.Len(t, result.Entries[1].Message.Content, 1)
+	assert.Equal(t, "text", result.Entries[1].Message.Content[0].Type)
+	assert.Equal(t, "partial response", result.Entries[1].Message.Content[0].Text)
+}


### PR DESCRIPTION
Adds a flush at the end of Copilot event parsing to emit pending assistant content when the stream ends mid-turn.

**Changes:**
- internal/transcript/copilot_parser.go: Added flush logic after event loop
- internal/transcript/copilot_parser_test.go: Added interrupted turn test

Fixes T-800