### PR TITLE
fix(T-868): Codex session listing drops sessions after large pre-meta lines

### DIFF
--- a/internal/sessions/lister.go
+++ b/internal/sessions/lister.go
@@ -529,6 +529,7 @@ func getCodexSessionTimestamp(path string) (time.Time, error) {
 	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	for i := 0; i < codexMetaScanLimit && scanner.Scan(); i++ {
 		var entry struct {
 			Timestamp string `json:"timestamp"`
@@ -563,6 +564,7 @@ func getCodexSessionCwd(path string) string {
 	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	for i := 0; i < codexMetaScanLimit && scanner.Scan(); i++ {
 		var entry struct {
 			Type    string          `json:"type"`

--- a/internal/sessions/lister_test.go
+++ b/internal/sessions/lister_test.go
@@ -1197,3 +1197,57 @@ func TestIsWithinDirResolvesSymlinkedPrefix(t *testing.T) {
 		t.Errorf("isWithinDir(%q, %q) = false, want true", resolvedFile, symlinkDir)
 	}
 }
+
+// TestCodexSessionCwdLargeLineBeforeMeta verifies that getCodexSessionCwd
+// handles JSONL lines exceeding the default 64 KiB scanner buffer.
+// Regression test for T-868.
+func TestCodexSessionCwdLargeLineBeforeMeta(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	ts := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	sessionID := "large-line-test"
+	projectPath := "/home/user/project"
+
+	dir := filepath.Join(homeDir, ".codex", "sessions",
+		ts.Format("2006"), ts.Format("01"), ts.Format("02"))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Create a line larger than the default 64 KiB scanner buffer.
+	largeText := strings.Repeat("x", 70*1024)
+	largeLine, _ := json.Marshal(map[string]any{
+		"type":      "response_item",
+		"timestamp": ts.Format(time.RFC3339),
+		"payload":   map[string]any{"type": "message", "content": largeText},
+	})
+
+	metaLine, _ := json.Marshal(map[string]any{
+		"type":      "session_meta",
+		"timestamp": ts.Format(time.RFC3339),
+		"payload":   map[string]any{"id": sessionID, "cwd": projectPath},
+	})
+
+	content := append(largeLine, '\n')
+	content = append(content, metaLine...)
+	content = append(content, '\n')
+
+	filePath := filepath.Join(dir, fmt.Sprintf("session-%s.jsonl", sessionID))
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cwd := getCodexSessionCwd(filePath)
+	if cwd != projectPath {
+		t.Errorf("getCodexSessionCwd() = %q, want %q", cwd, projectPath)
+	}
+
+	got, err := getCodexSessionTimestamp(filePath)
+	if err != nil {
+		t.Fatalf("getCodexSessionTimestamp() error: %v", err)
+	}
+	if !got.Equal(ts) {
+		t.Errorf("getCodexSessionTimestamp() = %v, want %v", got, ts)
+	}
+}


### PR DESCRIPTION
Fixes Transit ticket T-868: Codex session listing drops sessions after large pre-meta lines