### PR TITLE
fix(T-870): Kiro IDE listing mishandles empty project path

### DIFF
--- a/internal/sessions/lister.go
+++ b/internal/sessions/lister.go
@@ -23,10 +23,14 @@ import (
 // kiroDiscoverFunc abstracts Kiro session discovery for testing.
 type kiroDiscoverFunc func(ctx context.Context, dir string) ([]logs.SessionMetadata, error)
 
+// kiroIDEBasePathFunc abstracts Kiro IDE base path resolution for testing.
+type kiroIDEBasePathFunc func() (string, error)
+
 // Lister discovers sessions from all agent types for a project.
 type Lister struct {
-	homeDir      string
-	kiroDiscover kiroDiscoverFunc // nil → logs.DiscoverForDirectory
+	homeDir         string
+	kiroDiscover    kiroDiscoverFunc    // nil → logs.DiscoverForDirectory
+	kiroIDEBasePath kiroIDEBasePathFunc // nil → transcript.KiroIDEBasePath
 }
 
 // NewLister creates a Lister.
@@ -361,7 +365,12 @@ func (l *Lister) listKiro(cwd string) ([]SessionInfo, error) {
 }
 
 // listKiroIDE returns all Kiro IDE sessions for a project directory.
+// When projectPath is empty, scans all workspace directories.
 func (l *Lister) listKiroIDE(projectPath string) ([]SessionInfo, error) {
+	if projectPath == "" {
+		return l.listKiroIDEAll()
+	}
+
 	workspaceDir, err := transcript.KiroIDEWorkspaceDir(projectPath)
 	if err != nil {
 		if errors.Is(err, transcript.ErrKiroIDENotFound) {
@@ -370,6 +379,11 @@ func (l *Lister) listKiroIDE(projectPath string) ([]SessionInfo, error) {
 		return nil, fmt.Errorf("kiro ide workspace: %w", err)
 	}
 
+	return l.listKiroIDEWorkspace(workspaceDir)
+}
+
+// listKiroIDEWorkspace scans a single workspace directory for Kiro IDE sessions.
+func (l *Lister) listKiroIDEWorkspace(workspaceDir string) ([]SessionInfo, error) {
 	entries, err := os.ReadDir(workspaceDir)
 	if err != nil {
 		return nil, fmt.Errorf("read kiro ide workspace: %w", err)
@@ -465,6 +479,40 @@ func (l *Lister) listKiroIDE(projectPath string) ([]SessionInfo, error) {
 	}
 
 	return sessions, nil
+}
+
+// listKiroIDEAll scans all workspace hash directories under the Kiro IDE base path.
+func (l *Lister) listKiroIDEAll() ([]SessionInfo, error) {
+	baseFn := l.kiroIDEBasePath
+	if baseFn == nil {
+		baseFn = transcript.KiroIDEBasePath
+	}
+	base, err := baseFn()
+	if err != nil {
+		if errors.Is(err, transcript.ErrKiroIDENotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("kiro ide base path: %w", err)
+	}
+
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return nil, fmt.Errorf("read kiro ide base: %w", err)
+	}
+
+	var all []SessionInfo
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		workspaceDir := filepath.Join(base, entry.Name())
+		sessions, err := l.listKiroIDEWorkspace(workspaceDir)
+		if err != nil {
+			continue // skip unreadable workspaces
+		}
+		all = append(all, sessions...)
+	}
+	return all, nil
 }
 
 // --- Supporting functions and types ---

--- a/internal/sessions/lister_test.go
+++ b/internal/sessions/lister_test.go
@@ -1198,6 +1198,7 @@ func TestIsWithinDirResolvesSymlinkedPrefix(t *testing.T) {
 	}
 }
 
+
 // TestCodexSessionCwdLargeLineBeforeMeta verifies that getCodexSessionCwd
 // handles JSONL lines exceeding the default 64 KiB scanner buffer.
 // Regression test for T-868.
@@ -1249,5 +1250,68 @@ func TestCodexSessionCwdLargeLineBeforeMeta(t *testing.T) {
 	}
 	if !got.Equal(ts) {
 		t.Errorf("getCodexSessionTimestamp() = %v, want %v", got, ts)
+	}
+}
+
+// TestListKiroIDEEmptyPathScansAllWorkspaces verifies that listKiroIDE("")
+// scans all workspace hash directories instead of hashing the cwd (T-870).
+func TestListKiroIDEEmptyPathScansAllWorkspaces(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create two workspace directories with .chat files.
+	ws1 := filepath.Join(baseDir, "aaa111")
+	ws2 := filepath.Join(baseDir, "bbb222")
+	if err := os.MkdirAll(ws1, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(ws2, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	chat1, _ := json.Marshal(map[string]any{
+		"executionId": "exec-1",
+		"chat":        []map[string]any{{"role": "user", "content": "hi"}},
+		"metadata":    map[string]any{"startTime": 1700000000000},
+	})
+	chat2, _ := json.Marshal(map[string]any{
+		"executionId": "exec-2",
+		"chat":        []map[string]any{{"role": "user", "content": "hello"}},
+		"metadata":    map[string]any{"startTime": 1700000001000},
+	})
+	if err := os.WriteFile(filepath.Join(ws1, "a.chat"), chat1, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws2, "b.chat"), chat2, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also create a regular file at base level (should be skipped, not a dir).
+	if err := os.WriteFile(filepath.Join(baseDir, "not-a-dir"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lister := &Lister{
+		homeDir:         t.TempDir(),
+		kiroIDEBasePath: func() (string, error) { return baseDir, nil },
+	}
+
+	sessions, err := lister.listKiroIDE("")
+	if err != nil {
+		t.Fatalf("listKiroIDE(\"\") error: %v", err)
+	}
+
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(sessions))
+	}
+
+	ids := map[string]bool{}
+	for _, s := range sessions {
+		ids[s.ID] = true
+		if s.Source != SourceKiroIDE {
+			t.Errorf("session %s source = %q, want %q", s.ID, s.Source, SourceKiroIDE)
+		}
+	}
+	if !ids["exec-1"] || !ids["exec-2"] {
+		t.Errorf("expected exec-1 and exec-2, got %v", ids)
 	}
 }


### PR DESCRIPTION
Fixes Transit ticket T-870: Kiro IDE listing mishandles empty project path