### PR TITLE
fix(T-878): orbit register cannot auto-register date-subdir logs

### DIFF
--- a/cmd/orbit/register.go
+++ b/cmd/orbit/register.go
@@ -55,6 +55,14 @@ func registerCommand(args []string) error {
 		return fmt.Errorf("no valid orbit logs found in %s", path)
 	}
 
+	// If the directory itself doesn't have session files directly,
+	// resolve to the latest date-subdir that does.
+	if !hasDirectSessionFiles(logDir) {
+		if subDir := findLatestDateSubdir(logDir); subDir != "" {
+			logDir = subDir
+		}
+	}
+
 	// Get registry
 	regDir, err := getRegistryDir()
 	if err != nil {
@@ -151,13 +159,81 @@ func resolvePath(path string) (string, error) {
 
 // isValidOrbitLogDir checks if a directory contains valid orbit logs.
 // A directory is valid if it contains at least one phase session file
-// (either new format phase-N-run-M-session.json or legacy phase-N-session.json).
+// (either new format phase-N-run-M-session.json or legacy phase-N-session.json),
+// either directly or in a date-subdir subdirectory.
 func isValidOrbitLogDir(dir string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false
 	}
 
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			name := entry.Name()
+			if phaseSessionPattern.MatchString(name) || legacyPhaseSessionPattern.MatchString(name) {
+				return true
+			}
+			continue
+		}
+		// Check subdirectories for date-subdir mode
+		subEntries, err := os.ReadDir(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		for _, sub := range subEntries {
+			if sub.IsDir() {
+				continue
+			}
+			name := sub.Name()
+			if phaseSessionPattern.MatchString(name) || legacyPhaseSessionPattern.MatchString(name) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// findLatestDateSubdir finds the most recent date-subdir run directory within a base .orbit directory.
+// Returns empty string if no valid subdirectory is found.
+func findLatestDateSubdir(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+
+	var latest string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		subDir := filepath.Join(dir, entry.Name())
+		subEntries, err := os.ReadDir(subDir)
+		if err != nil {
+			continue
+		}
+		for _, sub := range subEntries {
+			if sub.IsDir() {
+				continue
+			}
+			name := sub.Name()
+			if phaseSessionPattern.MatchString(name) || legacyPhaseSessionPattern.MatchString(name) {
+				// Directories are sorted lexicographically; timestamp-prefixed names sort chronologically
+				latest = subDir
+				break
+			}
+		}
+	}
+
+	return latest
+}
+
+// hasDirectSessionFiles checks if a directory contains session files directly (not in subdirectories).
+func hasDirectSessionFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -167,7 +243,6 @@ func isValidOrbitLogDir(dir string) bool {
 			return true
 		}
 	}
-
 	return false
 }
 

--- a/cmd/orbit/register_test.go
+++ b/cmd/orbit/register_test.go
@@ -113,6 +113,27 @@ func TestIsValidOrbitLogDir(t *testing.T) {
 			t.Error("isValidOrbitLogDir() = true, want false")
 		}
 	})
+
+	t.Run("valid with date-subdir containing session files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create a date-subdir with session files
+		subDir := filepath.Join(tmpDir, "2025-01-15-143022-my-feature")
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			t.Fatalf("Failed to create subdir: %v", err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(subDir, "phase-1-session.json"),
+			[]byte("{}"),
+			0644,
+		); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		if !isValidOrbitLogDir(tmpDir) {
+			t.Error("isValidOrbitLogDir() = false, want true for date-subdir layout")
+		}
+	})
 }
 
 func TestDeriveStatus(t *testing.T) {
@@ -623,6 +644,81 @@ func TestRegisterCommand(t *testing.T) {
 
 		if len(entries[0].Phases) != 3 {
 			t.Errorf("len(Phases) = %d, want 3", len(entries[0].Phases))
+		}
+	})
+
+	t.Run("registers date-subdir log directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("HOME", tmpDir)
+
+		// Create a .orbit directory with only date-subdir runs (no direct session files)
+		logDir := filepath.Join(tmpDir, "project", ".orbit")
+		subDir := filepath.Join(logDir, "2025-01-15-143022-my-feature")
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			t.Fatalf("Failed to create subdir: %v", err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(subDir, "phase-1-session.json"),
+			[]byte("{}"),
+			0644,
+		); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		err := registerCommand([]string{logDir})
+		if err != nil {
+			t.Fatalf("registerCommand() error: %v", err)
+		}
+
+		// Verify registration points to the subdir
+		regDir, _ := getRegistryDir()
+		reg, _ := registry.New(regDir)
+		entries, _ := reg.List()
+
+		if len(entries) != 1 {
+			t.Fatalf("len(entries) = %d, want 1", len(entries))
+		}
+		if entries[0].LogDir != subDir {
+			t.Errorf("LogDir = %q, want %q", entries[0].LogDir, subDir)
+		}
+	})
+
+	t.Run("registers latest date-subdir when multiple exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("HOME", tmpDir)
+
+		logDir := filepath.Join(tmpDir, "project", ".orbit")
+		// Create two date-subdir runs
+		for _, name := range []string{"2025-01-14-100000-feat", "2025-01-15-143022-feat"} {
+			subDir := filepath.Join(logDir, name)
+			if err := os.MkdirAll(subDir, 0755); err != nil {
+				t.Fatalf("Failed to create subdir: %v", err)
+			}
+			if err := os.WriteFile(
+				filepath.Join(subDir, "phase-1-run-1-session.json"),
+				[]byte("{}"),
+				0644,
+			); err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+		}
+
+		err := registerCommand([]string{logDir})
+		if err != nil {
+			t.Fatalf("registerCommand() error: %v", err)
+		}
+
+		regDir, _ := getRegistryDir()
+		reg, _ := registry.New(regDir)
+		entries, _ := reg.List()
+
+		if len(entries) != 1 {
+			t.Fatalf("len(entries) = %d, want 1", len(entries))
+		}
+		// Should pick the latest (lexicographically last) subdir
+		want := filepath.Join(logDir, "2025-01-15-143022-feat")
+		if entries[0].LogDir != want {
+			t.Errorf("LogDir = %q, want %q", entries[0].LogDir, want)
 		}
 	})
 }


### PR DESCRIPTION
Fixes Transit ticket T-878: orbit register cannot auto-register date-subdir logs