### PR TITLE
fix(T-994): Preserve real session timestamps when resolving file-backed transcripts

### DIFF
--- a/internal/sessions/resolver.go
+++ b/internal/sessions/resolver.go
@@ -316,7 +316,7 @@ func (r *Resolver) openFileSession(path, source, sessionID string) (*ResolvedSes
 
 // resolveFileCreatedAt derives the session start timestamp using the same
 // source-specific logic as the lister. Falls back to modTime on failure.
-// For Claude and Codex, the file is seeked back to the start after parsing.
+// For Claude, the file is seeked back to the start after parsing.
 func (r *Resolver) resolveFileCreatedAt(f *os.File, path, source string, modTime time.Time) time.Time {
 	switch source {
 	case SourceClaude:
@@ -334,6 +334,10 @@ func (r *Resolver) resolveFileCreatedAt(f *os.File, path, source string, modTime
 		if ws, err := parseCopilotWorkspace(wsPath); err == nil && ws != nil && ws.CreatedAt != nil {
 			return *ws.CreatedAt
 		}
+	case SourceKiroCLI, SourceKiroIDE:
+		// Kiro CLI uses SQLite (handled by resolveKiroSession, not file-based).
+		// Kiro IDE embeds startTime in JSON but requires full parsing; fall
+		// through to modTime for now.
 	}
 	return modTime
 }

--- a/internal/sessions/resolver.go
+++ b/internal/sessions/resolver.go
@@ -285,7 +285,10 @@ func (r *Resolver) findKiroIDEPath(workspaceDir, sessionID string) (string, erro
 	return bestPath, nil
 }
 
-// openFileSession opens a file and returns a ResolvedSession with metadata from os.Stat.
+// openFileSession opens a file and returns a ResolvedSession with metadata.
+// It derives CreatedAt using the same source-specific logic as the lister
+// (transcript timestamps, session metadata, or workspace metadata) rather
+// than relying solely on file modification time.
 func (r *Resolver) openFileSession(path, source, sessionID string) (*ResolvedSession, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -298,15 +301,41 @@ func (r *Resolver) openFileSession(path, source, sessionID string) (*ResolvedSes
 		return nil, err
 	}
 
+	createdAt := r.resolveFileCreatedAt(f, path, source, info.ModTime())
+
 	return &ResolvedSession{
 		Reader: f,
 		Metadata: SessionMetadata{
 			Source:    source,
 			ID:        sessionID,
 			Size:      info.Size(),
-			CreatedAt: info.ModTime(),
+			CreatedAt: createdAt,
 		},
 	}, nil
+}
+
+// resolveFileCreatedAt derives the session start timestamp using the same
+// source-specific logic as the lister. Falls back to modTime on failure.
+// For Claude and Codex, the file is seeked back to the start after parsing.
+func (r *Resolver) resolveFileCreatedAt(f *os.File, path, source string, modTime time.Time) time.Time {
+	switch source {
+	case SourceClaude:
+		if ts, err := transcript.ParseFirstTimestamp(f); err == nil {
+			_, _ = f.Seek(0, io.SeekStart)
+			return ts
+		}
+		_, _ = f.Seek(0, io.SeekStart)
+	case SourceCodex:
+		if ts, err := getCodexSessionTimestamp(path); err == nil {
+			return ts
+		}
+	case SourceCopilot:
+		wsPath := filepath.Join(filepath.Dir(path), "workspace.yaml")
+		if ws, err := parseCopilotWorkspace(wsPath); err == nil && ws != nil && ws.CreatedAt != nil {
+			return *ws.CreatedAt
+		}
+	}
+	return modTime
 }
 
 // findCodexSession searches ~/.codex/sessions/ for a session by UUID or

--- a/internal/sessions/resolver_test.go
+++ b/internal/sessions/resolver_test.go
@@ -738,3 +738,101 @@ func mustMarshal(t *testing.T, v any) []byte {
 	require.NoError(t, err)
 	return data
 }
+
+// TestResolveFileCreatedAt_UsesTranscriptTimestamp verifies that the resolver
+// derives CreatedAt from source-specific transcript metadata (matching the
+// lister) rather than file modification time. Regression test for T-994.
+func TestResolveFileCreatedAt_UsesTranscriptTimestamp(t *testing.T) {
+	t.Run("claude", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectPath := t.TempDir()
+
+		sessionID := "ts-test-claude"
+		transcriptTime := time.Date(2025, 3, 10, 9, 0, 0, 0, time.UTC)
+
+		claudeProjectPath := claudecode.BuildProjectPath(projectPath)
+		dir := filepath.Join(homeDir, ".claude", "projects", claudeProjectPath)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+
+		entry := map[string]any{
+			"type":      "system",
+			"timestamp": transcriptTime.Format(time.RFC3339),
+			"message":   "init",
+		}
+		data, _ := json.Marshal(entry)
+		filePath := filepath.Join(dir, sessionID+".jsonl")
+		require.NoError(t, os.WriteFile(filePath, append(data, '\n'), 0644))
+
+		// Set file mtime to a different time to prove we don't use it.
+		differentTime := time.Date(2099, 12, 31, 23, 59, 0, 0, time.UTC)
+		require.NoError(t, os.Chtimes(filePath, differentTime, differentTime))
+
+		resolver := newTestResolver(projectPath, homeDir)
+		resolved, err := resolver.Resolve(SourceClaude, sessionID)
+		require.NoError(t, err)
+		defer func() { _ = resolved.Reader.Close() }()
+
+		assert.Equal(t, transcriptTime, resolved.Metadata.CreatedAt,
+			"CreatedAt should come from transcript first entry, not file mtime")
+	})
+
+	t.Run("codex", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectPath := t.TempDir()
+
+		sessionID := "12345678-aaaa-bbbb-cccc-123456789abc"
+		metaTime := time.Date(2025, 2, 20, 15, 0, 0, 0, time.UTC)
+
+		codexDir := filepath.Join(homeDir, ".codex", "sessions", "2025", "02", "20")
+		require.NoError(t, os.MkdirAll(codexDir, 0755))
+
+		meta := map[string]any{
+			"type":      "session_meta",
+			"timestamp": metaTime.Format(time.RFC3339),
+			"payload":   map[string]any{"id": sessionID, "cwd": projectPath},
+		}
+		data, _ := json.Marshal(meta)
+		filePath := filepath.Join(codexDir, fmt.Sprintf("session-%s.jsonl", sessionID))
+		require.NoError(t, os.WriteFile(filePath, append(data, '\n'), 0644))
+
+		differentTime := time.Date(2099, 12, 31, 23, 59, 0, 0, time.UTC)
+		require.NoError(t, os.Chtimes(filePath, differentTime, differentTime))
+
+		resolver := newTestResolver(projectPath, homeDir)
+		resolved, err := resolver.Resolve(SourceCodex, sessionID)
+		require.NoError(t, err)
+		defer func() { _ = resolved.Reader.Close() }()
+
+		assert.Equal(t, metaTime, resolved.Metadata.CreatedAt,
+			"CreatedAt should come from session_meta timestamp, not file mtime")
+	})
+
+	t.Run("copilot", func(t *testing.T) {
+		homeDir := t.TempDir()
+		projectPath := t.TempDir()
+
+		sessionID := "12345678-dddd-eeee-ffff-123456789abc"
+		wsTime := time.Date(2025, 4, 5, 8, 30, 0, 0, time.UTC)
+
+		sessionDir := filepath.Join(homeDir, ".copilot", "session-state", sessionID)
+		require.NoError(t, os.MkdirAll(sessionDir, 0755))
+
+		eventsPath := filepath.Join(sessionDir, "events.jsonl")
+		require.NoError(t, os.WriteFile(eventsPath, []byte(`{"type":"event"}`+"\n"), 0644))
+
+		yamlContent := fmt.Sprintf("id: %s\ncwd: %s\ncreated_at: %s\n",
+			sessionID, projectPath, wsTime.Format(time.RFC3339))
+		require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "workspace.yaml"), []byte(yamlContent), 0644))
+
+		differentTime := time.Date(2099, 12, 31, 23, 59, 0, 0, time.UTC)
+		require.NoError(t, os.Chtimes(eventsPath, differentTime, differentTime))
+
+		resolver := newTestResolver(projectPath, homeDir)
+		resolved, err := resolver.Resolve(SourceCopilot, sessionID)
+		require.NoError(t, err)
+		defer func() { _ = resolved.Reader.Close() }()
+
+		assert.Equal(t, wsTime, resolved.Metadata.CreatedAt,
+			"CreatedAt should come from workspace.yaml created_at, not file mtime")
+	})
+}


### PR DESCRIPTION
Fixes Transit ticket T-994: Preserve real session timestamps when resolving file-backed transcripts