### PR TITLE
fix(T-1008): Comparison context skips uppercase TASKS.md

### DIFF
--- a/cmd/orbit/compare.go
+++ b/cmd/orbit/compare.go
@@ -327,20 +327,27 @@ func formatDuration(d time.Duration) string {
 func readSpecContext(specDir string) string {
 	var parts []string
 
-	// Key spec files to include
+	// Key spec files to include (with fallback alternatives)
 	specFiles := []struct {
-		name  string
+		names []string
 		label string
 	}{
-		{"requirements.md", "Requirements"},
-		{"design.md", "Design"},
-		{"tasks.md", "Tasks"},
+		{[]string{"requirements.md"}, "Requirements"},
+		{[]string{"design.md"}, "Design"},
+		{[]string{"tasks.md", "TASKS.md"}, "Tasks"},
 	}
 
 	for _, sf := range specFiles {
-		path := filepath.Join(specDir, sf.name)
-		content, err := os.ReadFile(path)
-		if err != nil {
+		var content []byte
+		for _, name := range sf.names {
+			path := filepath.Join(specDir, name)
+			var err error
+			content, err = os.ReadFile(path)
+			if err == nil {
+				break
+			}
+		}
+		if content == nil {
 			continue // Skip files that don't exist
 		}
 

--- a/cmd/orbit/compare_test.go
+++ b/cmd/orbit/compare_test.go
@@ -136,3 +136,19 @@ func runCmd(t *testing.T, dir string, name string, args ...string) {
 		t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
 	}
 }
+
+// TestReadSpecContext_UppercaseTasksFile verifies that readSpecContext picks up
+// TASKS.md when tasks.md does not exist (T-1008).
+func TestReadSpecContext_UppercaseTasksFile(t *testing.T) {
+	specDir := t.TempDir()
+
+	// Create only TASKS.md (uppercase)
+	if err := os.WriteFile(filepath.Join(specDir, "TASKS.md"), []byte("# Tasks\n- task 1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := readSpecContext(specDir)
+	if !strings.Contains(result, "# Tasks") {
+		t.Fatalf("expected TASKS.md content in spec context, got: %q", result)
+	}
+}

--- a/internal/orbit/comparison.go
+++ b/internal/orbit/comparison.go
@@ -312,20 +312,27 @@ func (o *Orbit) generateReport(ctx context.Context, allFailed bool) error {
 func (o *Orbit) readSpecContext() string {
 	var parts []string
 
-	// Key spec files to include
+	// Key spec files to include (with fallback alternatives)
 	specFiles := []struct {
-		name  string
+		names []string
 		label string
 	}{
-		{"requirements.md", "Requirements"},
-		{"design.md", "Design"},
-		{"tasks.md", "Tasks"},
+		{[]string{"requirements.md"}, "Requirements"},
+		{[]string{"design.md"}, "Design"},
+		{[]string{"tasks.md", "TASKS.md"}, "Tasks"},
 	}
 
 	for _, sf := range specFiles {
-		path := filepath.Join(o.config.SpecDir, sf.name)
-		content, err := os.ReadFile(path)
-		if err != nil {
+		var content []byte
+		for _, name := range sf.names {
+			path := filepath.Join(o.config.SpecDir, name)
+			var err error
+			content, err = os.ReadFile(path)
+			if err == nil {
+				break
+			}
+		}
+		if content == nil {
 			continue // Skip files that don't exist
 		}
 


### PR DESCRIPTION
Fixes Transit ticket T-1008: Comparison context skips uppercase TASKS.md