### PR TITLE
fix(T-1031): Graceful server shutdown returns http.ErrServerClosed

### DIFF
--- a/internal/apsisweb/server.go
+++ b/internal/apsisweb/server.go
@@ -98,7 +98,7 @@ func (s *Server) Start() error {
 	if err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("server error: %w", err)
 	}
-	return err
+	return nil
 }
 
 // Shutdown gracefully stops the server.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -122,7 +122,7 @@ func (s *Server) Start() error {
 	default:
 	}
 
-	return err
+	return nil
 }
 
 // Shutdown gracefully stops the server.


### PR DESCRIPTION
Fixes Transit ticket T-1031: Graceful server shutdown returns http.ErrServerClosed