### PR TITLE
Fix Claude session-limit message detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `orbit finalize` now displays the variant's agent (alias, type, model) in its preamble, falling back to "Agent: unknown" when none of the fields are populated.
 - `orbit finalize` now reads the spec's `consolidation-log.json` and prints a warning before the confirmation prompt when the requested `--variant` differs from the most recent consolidation entry. The warning fires under `--force` as well so it remains visible in CI output.
 
+### Fixed
+
+- Claude Code session-limit messages using the new `"You've hit your session limit"` wording now wait until the reported reset time while retaining support for the older message.
+
 ## [0.9.0] - 2026-04-11
 
 Initial public release of Orbit and Apsis.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,7 @@ Retry logic is centralized in `internal/agents/retry.go` via `RunWithRetry()`, w
 
 ### Usage Limit Handling (Claude Code)
 
-Claude Code has a 5-hour usage limit that displays messages like "You've hit your limit · resets 3am (Australia/Melbourne)". When this occurs, Orbit will:
+Claude Code displays session-limit messages like "You've hit your session limit · resets 3am (Australia/Melbourne)". Orbit also accepts the older "You've hit your limit" wording. When this occurs, Orbit will:
 1. Parse the reset time and timezone from the error message
 2. Calculate the wait duration until that time (plus a 1-minute buffer)
 3. Wait automatically until the limit resets

--- a/internal/agents/claudecode/errors.go
+++ b/internal/agents/claudecode/errors.go
@@ -29,12 +29,13 @@ func (c *Classifier) Classify(exitCode int, stderr, stdout string, errMsgs []str
 	combined := stderr + stdout + strings.Join(errMsgs, " ")
 	combinedLower := strings.ToLower(combined)
 
-	// Check for usage limit (5-hour limit) - must check before regular rate limit
+	// Check for session/usage limits - must check before regular rate limits.
 	// Example messages:
 	//   "You've hit your limit · resets 3am (Australia/Melbourne)"
+	//   "You've hit your session limit · resets 4pm (Australia/Melbourne)"
 	//   "You've hit your limit · resets 3am"
 	if strings.Contains(combinedLower, "hit your limit") ||
-		strings.Contains(combinedLower, "you've hit your limit") {
+		strings.Contains(combinedLower, "hit your session limit") {
 		waitDuration := parseUsageLimitReset(combined)
 		if waitDuration > 0 {
 			return &agents.ClassifiedError{
@@ -74,7 +75,6 @@ func (c *Classifier) Classify(exitCode int, stderr, stdout string, errMsgs []str
 
 	return agents.NewUnknownError("claude-code", errMsgs, stderr, stdout)
 }
-
 
 // parseUsageLimitReset parses the reset time from usage limit messages.
 // Example messages:

--- a/internal/agents/claudecode/errors_test.go
+++ b/internal/agents/claudecode/errors_test.go
@@ -148,7 +148,6 @@ func TestClassifier_Classify_ErrMsgs(t *testing.T) {
 	}
 }
 
-
 func TestClassifier_ImplementsInterface(t *testing.T) {
 	// This test verifies that Classifier implements ErrorClassifier
 	classifier := NewClassifier()
@@ -166,6 +165,7 @@ func TestClassifier_Classify_UsageLimit(t *testing.T) {
 		stdout string
 	}{
 		{"hit your limit", "You've hit your limit · resets 3am (Australia/Melbourne)", ""},
+		{"hit your session limit", "You've hit your session limit · resets 4pm (Australia/Melbourne)", ""},
 		{"hit your limit in stdout", "", "You've hit your limit · resets 5pm (America/New_York)"},
 		{"lowercase hit limit", "you've hit your limit resets 12am (UTC)", ""},
 	}

--- a/specs/bugfixes/claude-session-limit-message/report.md
+++ b/specs/bugfixes/claude-session-limit-message/report.md
@@ -1,0 +1,83 @@
+# Bugfix Report: Claude Session Limit Message
+
+**Date:** 2026-07-22
+**Status:** Fixed
+
+## Description of the Issue
+
+Claude Code now reports usage exhaustion as `"You've hit your session limit · resets 4pm (Australia/Melbourne)"`. Orbit only recognizes the older `"You've hit your limit"` prefix, so it does not wait until the supplied reset time.
+
+**Reproduction steps:**
+1. Pass the new Claude Code session-limit message to the Claude error classifier.
+2. Let the classifier inspect the message and reset time.
+3. Observe that it returns `ErrorClassUnknown` instead of `ErrorClassRateLimitWait`.
+
+**Impact:** Orbit can stop an in-progress Claude Code run when the session limit is reached instead of waiting and resuming after the reset.
+
+## Investigation Summary
+
+The failure occurs in the phrase-detection guard in `Classifier.Classify`; the existing reset-time parser already accepts the remainder of the new message.
+
+- **Symptoms examined:** The new message is classified as unknown with a zero retry delay.
+- **Code inspected:** `internal/agents/claudecode/errors.go`, its callers in the Claude agent and shared retry path, and `internal/agents/claudecode/errors_test.go`.
+- **Hypotheses tested:** A regression test confirmed that `parseUsageLimitReset` can parse the new reset suffix, but `Classify` never calls it because `"hit your limit"` is not present in `"hit your session limit"`.
+
+## Discovered Root Cause
+
+`Classifier.Classify` uses a literal substring guard tied to Claude Code's old wording. Claude inserted the word `session`, causing the guard to fail before the format-independent reset parser runs.
+
+**Defect type:** Missing external-message variant handling
+
+**Why it occurred:** The classifier relied on a specific upstream phrase; test coverage contained only that phrase; Claude changed the phrase while preserving the reset-time syntax; Orbit consequently fell through to unknown-error handling instead of its rate-limit wait path.
+
+**Contributing factors:** Claude Code's human-readable limit message is an external interface that can change independently of Orbit.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `internal/agents/claudecode/errors.go` - Recognize `"hit your session limit"` before parsing the reset time, while retaining support for the older phrase.
+- `internal/agents/claudecode/errors_test.go` - Add the new Claude Code wording to the classifier regression cases.
+- `CLAUDE.md` - Document the current wording and compatibility with the older message.
+
+**Approach rationale:** An explicit second accepted phrase is the smallest safe change. It reuses the existing reset-time parser and avoids treating unrelated messages containing `"resets <time>"` as Claude session limits.
+
+**Alternatives considered:**
+- Parse every error containing a reset time - Rejected because unrelated reset messages could be misclassified as session limits.
+- Replace the guard with a looser regular expression - Rejected because two known literal variants are clearer and sufficient.
+
+## Regression Test
+
+**Test file:** `internal/agents/claudecode/errors_test.go`
+**Test name:** `TestClassifier_Classify_UsageLimit/hit_your_session_limit`
+
+**What it verifies:** The new session-limit message is classified as `ErrorClassRateLimitWait` with a positive retry delay.
+
+**Run command:** `go test ./internal/agents/claudecode -run TestClassifier_Classify_UsageLimit`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `internal/agents/claudecode/errors.go` | Recognize the new session-limit phrase |
+| `internal/agents/claudecode/errors_test.go` | Add the regression case |
+| `CLAUDE.md` | Update the documented Claude Code message |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] All non-server packages pass
+- [x] Linters/validators pass
+- [ ] Full `make test` passes in this sandbox; listener tests are blocked by `bind: operation not permitted`
+
+**Manual verification:**
+- Confirmed the exact reported message produces `ErrorClassRateLimitWait` with a positive reset delay through the regression test.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Keep explicit regression cases for each observed Claude Code limit-message variant.
+
+## Related
+
+- Supersedes no existing bugfix; the older message remains supported.


### PR DESCRIPTION
## Summary

- recognize Claude Code's new `You've hit your session limit` wording
- preserve support for the previous usage-limit message
- add regression coverage and update documentation

## Validation

- `go test ./internal/agents/claudecode -run TestClassifier_Classify_UsageLimit`
- all non-server Go packages
- `make lint`

`make test` was also attempted locally; listener-dependent tests are blocked by the sandbox's `bind: operation not permitted` restriction.